### PR TITLE
Adds a React Native base template

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/node12/tsconfig.json"
 ```
+### React Native <kbd><a href="./bases/react-native.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/react-native
+yarn add --dev @tsconfig/react-native
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/react-native/tsconfig.json"
+```
 ### Node 10 <kbd><a href="./bases/node10.json">tsconfig.json</a></kbd>
 
 Install:

--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -1,0 +1,19 @@
+{
+  "display": "React Native",
+  
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "lib": ["es6"],
+    "allowJs": true,
+    "jsx": "react-native",
+    "noEmit": true,
+    "isolatedModules": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
+}


### PR DESCRIPTION
This takes the template from the ts [react-native-template](https://github.com/react-native-community/react-native-template-typescript/blob/master/template/tsconfig.json), given that it's entirely generic right now I think this _could_ work for any RN app using `rn init`

Interesting that Expo's is a bit more bare: https://github.com/expo/expo/blob/master/templates/expo-template-bare-typescript/tsconfig.json

Fixes #8 