### PR TITLE
Add react native support for Array.includes and Object.{entries,values}

### DIFF
--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
-    "lib": ["es6"],
+    "lib": ["es6", "es2016.array.include", "es2017.object"],
     "allowJs": true,
     "jsx": "react-native",
     "noEmit": true,


### PR DESCRIPTION
This updates the React Native config to support Array.includes and Object.{entries,values}, as specified by the [React Native JavaScript Environment documentation](https://reactnative.dev/docs/javascript-environment).