### PR TITLE
adjust node 12 config according to node.green

### DIFF
--- a/bases/node12.json
+++ b/bases/node12.json
@@ -3,7 +3,7 @@
   "display": "Node 12",
 
   "compilerOptions": {
-    "lib": ["es2019", "es2020.promise", "es2020.bigint", "lib.es2020.string"],
+    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
     "module": "commonjs",
     "target": "es2019"
   }  

--- a/bases/node12.json
+++ b/bases/node12.json
@@ -3,8 +3,8 @@
   "display": "Node 12",
 
   "compilerOptions": {
-    "lib": ["es2018"],
+    "lib": ["es2019", "es2020.promise", "es2020.bigint", "lib.es2020.string"],
     "module": "commonjs",
-    "target": "es2018"
+    "target": "es2019"
   }  
 }


### PR DESCRIPTION
es2020.promise is only supported starting node>= 12.10.x, since the LTS listed on the website, is 12.18.x, I also enabled it.

See https://node.green/#ES2020