### PR TITLE
feat: Add repository on package.json template

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Create a set of npm packages via:
 deno run --allow-read --allow-write --allow-net scripts/create-npm-packages.ts
 ```
 
-You can inspect them in the `dist/` folder, then they are deployed by passing in the paths to the base files via stdin: 
+You can inspect them in the `packages/` folder, then they are deployed by passing in the paths to the base files via stdin: 
 
 ```sh
 echo bases/node10.json | deno run --allow-read --allow-run --allow-env scripts/deploy-npm-packages.ts

--- a/template/package.json
+++ b/template/package.json
@@ -1,4 +1,9 @@
 {
   "name": "replaced-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tsconfig/bases.git",
+    "directory": "bases"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
When accessing the npm website, there is no link to the Github repository, which makes it harder for users to find out which flags are being applied when they extend a base.

![image](https://user-images.githubusercontent.com/17657014/88116767-b8d5c280-cb8f-11ea-95b7-1d7bddcc5ba4.png)
