### PR TITLE
Remove "types" from svelte base

### DIFF
--- a/bases/svelte.json
+++ b/bases/svelte.json
@@ -16,9 +16,6 @@
       enable source maps by default.
      */
     "sourceMap": true,
-    
-    /** Requests the runtime types from the svelte modules by default */
-    "types": ["svelte"],
 
     "strict": false,
     "esModuleInterop": true,


### PR DESCRIPTION
Was necessary to get completions for things such as `onMount`. Obsolete now because of this PR https://github.com/sveltejs/language-tools/pull/441 which adds the typings through `///` at the top of every svelte2tsx file.