### PR TITLE
Svelte: revert types removal

### DIFF
--- a/bases/svelte.json
+++ b/bases/svelte.json
@@ -16,6 +16,8 @@
       enable source maps by default.
      */
     "sourceMap": true,
+    /** Requests the runtime types from the svelte modules by default. Needed for TS files or else you get errors. */
+    "types": ["svelte"],
 
     "strict": false,
     "esModuleInterop": true,


### PR DESCRIPTION
I was too quick on removing these from the types. They are needed for TypeScript files. If omitted, it will throw `Cannot find module './App.svelte' or its corresponding type declarations` errors.