### PR TITLE
feat(bases): add create-react-app base

### DIFF
--- a/bases/create-react-app.json
+++ b/bases/create-react-app.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Create React App",
+
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "target": "es5",
+
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Following #38, here is a base extracted from a brand new `create-react-app` as of today.

```
npx create-react-app --template typescript my-app
```

Tried to run deno following contributing docs but encountered an error

```bash
Developer/typescript/bases  patch ✗                                                                                                                                                                                                                                                                                                                                                                                             1m ⚑ ◒  ⍉
▶ deno run --allow-read --allow-run --allow-env --allow-write --allow-net scripts/generate-recommend.ts
npx: installed 1 in 1.265s
message TS6071: Successfully created a tsconfig.json file.

error: Uncaught (in promise) ReferenceError: SyntaxKind is not defined
		token: SyntaxKind = SyntaxKind.Unknown,
		                    ^
    at createScanner (scanner.ts:19:23)
    at visit (parser.ts:388:19)
    at parse (parser.ts:204:2)
    at generate-recommend.ts:15:16
```

```bash
▶ deno --version
deno 1.5.3 (UNKNOWN, release, x86_64-apple-darwin)
v8 8.7.220.3
typescript 4.0.5
```