### PR TITLE
Add noUncheckedIndexedAccess to node bases

### DIFF
--- a/bases/node10.json
+++ b/bases/node10.json
@@ -8,6 +8,7 @@
     "target": "es2018",
     
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true

--- a/bases/node12.json
+++ b/bases/node12.json
@@ -8,6 +8,7 @@
     "target": "es2019",
 
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true

--- a/bases/node14.json
+++ b/bases/node14.json
@@ -8,6 +8,7 @@
     "target": "es2020",
 
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Hey,

The new `noUncheckedIndexedAccess` setting improves type safety so I figured it make sense to add it. Hope you agree?

I'm only using Node currently, but happy to add it to the other bases too.