### PR TITLE
chore(react-native): update to latest generated tsconfig.json from re…

### DIFF
--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -1,20 +1,26 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "React Native",
-  
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
-    "lib": ["es6", "es2016.array.include", "es2017.object"],
+    "lib": [
+      "es2017"
+    ],
     "allowJs": true,
     "jsx": "react-native",
     "noEmit": true,
     "isolatedModules": true,
     "strict": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": false
   },
-  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
+  "exclude": [
+    "node_modules",
+    "babel.config.js",
+    "metro.config.js",
+    "jest.config.js"
+  ]
 }


### PR DESCRIPTION
…act-native init

I think we should stay in sync with the "official" `tsconfig.json` generated by:

```sh
npx react-native init MyApp --template react-native-template-typescript
```

Updated as of `react-native@0.64.0`.
