### PR TITLE
es2021 -> es2020

### DIFF
--- a/bases/node16.json
+++ b/bases/node16.json
@@ -3,9 +3,9 @@
   "display": "Node 16",
 
   "compilerOptions": {
-    "lib": ["es2021"],
+    "lib": ["es2020"],
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2020",
 
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Discussed in #50. Without this TypeScript complains as `es2021` target is currently only available in 4.3 beta.