### PR TITLE
Svelte: Removes "types" property

### DIFF
--- a/bases/svelte.json
+++ b/bases/svelte.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Svelte",
+  "_version": "2.0.0",
 
   "compilerOptions": {
     "moduleResolution": "node",
@@ -16,8 +17,6 @@
       enable source maps by default.
      */
     "sourceMap": true,
-    /** Requests the runtime types from the svelte modules by default. Needed for TS files or else you get errors. */
-    "types": ["svelte"],
 
     "strict": false,
     "esModuleInterop": true,


### PR DESCRIPTION
Remove the `types` property from the Svelte base config. Having it in there was causing some confusion for people who needed access to other global types, because they were "removed" by having this `types` definition.
To not get TS errors for the now missing global Svelte definitions, users should add `/// <reference types="svelte" />` to a `d.ts` file instead, which will also load these global definitions.
Since this is a breaking change, the version is bumped to `2.0.0`