### PR TITLE
es2020 -> es2021

### DIFF
--- a/bases/node16.json
+++ b/bases/node16.json
@@ -3,9 +3,9 @@
   "display": "Node 16",
 
   "compilerOptions": {
-    "lib": ["es2020"],
+    "lib": ["es2021"],
     "module": "commonjs",
-    "target": "es2020",
+    "target": "es2021",
 
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
[4.3 is out.](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-3.html) While the docs and schemastore haven't updated to include `es2021` yet, it is indeed supported for both [lib](https://github.com/microsoft/TypeScript/blob/v4.3.2/src/compiler/commandLineParser.ts#L20-L32) and [target](https://github.com/microsoft/TypeScript/blob/v4.3.2/src/compiler/commandLineParser.ts#L285-L299).

Related to #50