### PR TITLE
Expand readme template

### DIFF
--- a/readme-extras/svelte.md
+++ b/readme-extras/svelte.md
@@ -1,0 +1,1 @@
+> **NOTE**: After `@tsconfig/svelte@2.0.0`, you should add `/// <reference types="svelte" />` to a `d.ts` or a `index.ts`(entry) file to prevent typescript error.

--- a/scripts/create-npm-packages.ts
+++ b/scripts/create-npm-packages.ts
@@ -44,6 +44,20 @@ for await (const tsconfigEntry of Deno.readDir("bases")) {
     packageText = packageText.replace(/\[filename\]/g, name)
                              .replace(/\[display_title\]/g, title)
                              .replace(/\[tsconfig\]/g, Deno.readTextFileSync(tsconfigFilePath))
+    
+    // Inject readme-extra if any
+    try {
+      const readmeExtra = (await Deno.readTextFile(path.join(packagePath, "readme-extras", `${name}.md`))).trim()
+      
+      if (readmeExtra)
+        packageText = packageText.replace(/\[readme-extra\]/g, `\n${readmeExtra}\n`)
+    } catch (error) {
+      // NOOP, there is no extra readme 
+      // console.log(error)
+    }
+    
+    // Remove readme-extra placeholders if any
+    packageText = packageText.replace(/\[readme-extra\]/g, '')
 
     await Deno.writeTextFile(fileToEdit, packageText)
   };

--- a/scripts/update-markdown-readme.ts
+++ b/scripts/update-markdown-readme.ts
@@ -37,6 +37,13 @@ Add to your \`tsconfig.json\`:
 "extends": "@tsconfig/${name}/tsconfig.json"
 \`\`\`
 `
+
+  try {
+    const readmeExtra = (await Deno.readTextFile(`./readme-extras/${name}.md`)).trim()
+
+    if (readmeExtra)
+      center += `\n${readmeExtra}\n`
+  } catch (error) {}
 };
 
 const startMarker ="<!-- AUTO -->"

--- a/template/README.md
+++ b/template/README.md
@@ -12,7 +12,7 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/[filename]/tsconfig.json"
 ```
-
+[readme-extra]
 ---
 
 The `tsconfig.json`: 


### PR DESCRIPTION
It handles #66 and provides ability to add extra readme content for each configurations individually.

**NOTE**: This will affect to the README.md, so we have to run `deno run --allow-read --allow-write scripts/update-
markdown-readme.ts` once.

We can add extra readme individually by creating a `[name].md` file in the `readme-extras` directory. These are injected into the `README.md` for both this repo and the npm page.