### PR TITLE
Add @docusaurus/theme-classic to compilerOptions.types

### DIFF
--- a/bases/docusaurus.json
+++ b/bases/docusaurus.json
@@ -10,6 +10,6 @@
     "lib": ["DOM"],
     "noEmit": true,
     "noImplicitAny": false,
-    "types": ["node", "@docusaurus/module-type-aliases"]
+    "types": ["node", "@docusaurus/module-type-aliases", "@docusaurus/theme-classic"]
   }
 }


### PR DESCRIPTION

By default, 99,9% of users are going to use the Docusaurus classic theme anyway so it does not make sense to not include the classic theme types by default in the TS config, even if it creates some additional coupling, + it's possible to override it anyway.

When we'll have multiple themes in the future we'll create a shared package for common theme types (the Tailwind theme would have the same types as the classic theme). Still, we'll keep this coupling and bias toward the "official themes" by default for simplicity.

Related to https://github.com/facebook/docusaurus/issues/5282
