### PR TITLE
Update react-native.json

### DIFF
--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "strict": true,
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": false


### PR DESCRIPTION
Enables importing `.json` files. Metro's default behavior is to allow importing json files as JS objects.

- React Native community TS template include this option by default: https://github.com/react-native-community/react-native-template-typescript/blob/b3300f9c7fc383504b1a0b3abaffc801eea830e8/template/tsconfig.json#L49
- Expo also https://docs.expo.dev/guides/typescript/