### PR TITLE
Use new preserveValueImports in Svelte config

### DIFF
--- a/bases/svelte.json
+++ b/bases/svelte.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Svelte",
-  "_version": "2.0.0",
+  "_version": "3.0.0",
 
   "compilerOptions": {
     "moduleResolution": "node",
@@ -11,6 +11,11 @@
       to enforce using `import type` instead of `import` for Types.
      */
     "importsNotUsedAsValues": "error",
+    /**
+      TypeScript doesn't know about import usages in the template because it only sees the
+      script of a Svelte file. Therefore preserve all value imports. Requires TS 4.5 or higher.
+     */
+    "preserveValueImports": true,
     "isolatedModules": true,
     /**
       To have warnings/errors of the Svelte compiler at the correct position,


### PR DESCRIPTION
Since this requires TS 4.5 or higher, this requires a major version bump (please correct me if I'm wrong, but I think that's the case because TS will error on unknown flags). This can also be seen as a major change in behavior that some people may not want (yet), so that justifies the major version bump as well.