### PR TITLE
Display correct packages for combined configs

### DIFF
--- a/scripts/update-markdown-readme.ts
+++ b/scripts/update-markdown-readme.ts
@@ -16,7 +16,7 @@ const sortedPaths = paths.sort((l, r) => l.localeCompare(r)).filter(r => !r.incl
 const basePaths = ["recommended.json", ...sortedPaths]
 for (const base of basePaths) {
   const tsconfigFilePath = path.join("bases", base)
-  const name = path.basename(base).replace(".json", "").replace(".combined", "")
+  const name = path.basename(base).replace(".json", "")
   
   const tsconfigText = await Deno.readTextFile(tsconfigFilePath)
   const tsconfigJSON = parse(tsconfigText)


### PR DESCRIPTION
As the base names (without a suffix) are not resolvable via npm: [this](https://www.npmjs.com/package/@tsconfig/node16-strictest.combined) resolves correctly, [this](https://www.npmjs.com/package/@tsconfig/node16-strictest) (the version present in README.md) does not.

See #91.