### PR TITLE
Split install command into two fenced code blocks

### DIFF
--- a/scripts/update-markdown-readme.ts
+++ b/scripts/update-markdown-readme.ts
@@ -28,6 +28,9 @@ Install:
 
 \`\`\`sh
 npm install --save-dev @tsconfig/${name}
+\`\`\`
+
+\`\`\`sh
 yarn add --dev @tsconfig/${name}
 \`\`\`
 


### PR DESCRIPTION
Github has the option of copying the contents of a fenced code block:

<img width="602" alt="image" src="https://user-images.githubusercontent.com/174864/155645704-daa8c05f-b30f-47a3-b4a3-b1d741a540c9.png">

As you can see, however, when reading this project one ends up copying both a `yarn` and an `npm` command. With this PR the `yarn` and `npm` commands are put into their own fenced codeblocks for easier copying.