### PR TITLE
Add a base for Node 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,20 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/node16/tsconfig.json"
 ```
+### Node 17 <kbd><a href="./bases/node17.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/node17
+yarn add --dev @tsconfig/node17
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/node17/tsconfig.json"
+```
 ### Nuxt <kbd><a href="./bases/nuxt.json">tsconfig.json</a></kbd>
 
 Install:

--- a/bases/node17.json
+++ b/bases/node17.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 17",
+
+  "compilerOptions": {
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "target": "es2022",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true
+  }
+}


### PR DESCRIPTION
Self-explanatory; see #81.

I'm not sure about `useDefineForClassFields`, as it's enabled by default for `es2022` targets anyway.

Note: [lib][2] and [target][3] for 4.6 do support it - though it's RC, so it's understandable that the schema [hasn't been updated][1] yet.

[1]: https://json.schemastore.org/tsconfig
[2]: https://github.com/microsoft/TypeScript/blob/v4.6-rc/src/compiler/commandLineParser.ts#L36
[3]: https://github.com/microsoft/TypeScript/blob/v4.6-rc/src/compiler/commandLineParser.ts#L329