### PR TITLE
clean: remove extraneous alwaysStrict setting

### DIFF
--- a/bases/node16-strictest-esm.combined.json
+++ b/bases/node16-strictest-esm.combined.json
@@ -13,7 +13,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "alwaysStrict": true,
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,
     "exactOptionalPropertyTypes": true,

--- a/bases/node16-strictest.combined.json
+++ b/bases/node16-strictest.combined.json
@@ -13,7 +13,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "alwaysStrict": true,
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,
     "exactOptionalPropertyTypes": true,

--- a/bases/strictest.json
+++ b/bases/strictest.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-    "alwaysStrict": true,
-
     "strict": true,
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,


### PR DESCRIPTION
## Summary

`alwaysStrict` will be turned on when `strict` is on, so no need to set it again
- per the TypeScript Website, related to some PRs I once made to it https://github.com/microsoft/TypeScript-Website/pull/500, https://github.com/microsoft/TypeScript-Website/pull/971

## Details

- only changed `strictest.json` and the two other configs generated from/combined with it

- afaik the rest of the settings are indeed additional and not set by `strict`