### PR TITLE
Add base for node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/node17/tsconfig.json"
 ```
+### Node 18 <kbd><a href="./bases/node18.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/node18
+yarn add --dev @tsconfig/node18
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/node18/tsconfig.json"
+```
 ### Nuxt <kbd><a href="./bases/nuxt.json">tsconfig.json</a></kbd>
 
 Install:

--- a/bases/node18.json
+++ b/bases/node18.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 18",
+
+  "compilerOptions": {
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "target": "es2022",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
According to https://node.green/#ES2022, Node 18 is 97% complete on ES2022 so should be safe to define it in both `target` and `lib`