### PR TITLE
Ember: point to docs.ember-cli-typescript.com

### DIFF
--- a/bases/ember.json
+++ b/bases/ember.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Ember",
-  "docs": "https://guides.emberjs.com/release/",
+  "docs": "https://docs.ember-cli-typescript.com",
 
   // This is the base config used by Ember apps and addons. When actually used
   // via Ember CLI (e.g. ember-cli-typescript's blueprint), it additionally has


### PR DESCRIPTION
Eventually this will live in Ember's own docs, but not yet!