### PR TITLE
Add skipLibCheck in docusaurus.json

### DIFF
--- a/bases/docusaurus.json
+++ b/bases/docusaurus.json
@@ -9,11 +9,11 @@
     "jsx": "react",
     "lib": ["DOM"],
     "noEmit": true,
-    "noImplicitAny": false,
     "types": ["node", "@docusaurus/module-type-aliases", "@docusaurus/theme-classic"],
     "baseUrl": ".",
     "paths": {
       "@site/*": ["./*"]
-    }
+    },
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
[Our E2E tests](https://github.com/facebook/docusaurus/runs/6811305014?check_suite_focus=true) are failing, because `moduleResolution: node` would not resolve the `exports` map. Instead of forcing `moduleResolution: NodeNext` on the users, who may not be on 4.7, I just added `skipLibCheck`.