### PR TITLE
Update es2017 to es2019

### DIFF
--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -7,7 +7,7 @@
     "module": "commonjs",
     "types": ["react-native", "jest"],
     "lib": [
-      "es2017"
+      "es2019"
     ],
     "allowJs": true,
     "jsx": "react-native",


### PR DESCRIPTION
As @retyui pointed out 🙏 our new minimal iOS version for RN 0.69 is 12.4
- https://github.com/react-native-community/react-native-template-typescript/issues/275
  - https://github.com/facebook/react-native/commit/982ca30de079d7e80bd0b50365d58b9048fb628f

We've updated our template too now
- https://github.com/react-native-community/react-native-template-typescript/pull/276

I bumped our Hermes podspec earlier as well
- https://github.com/facebook/react-native/pull/33939
  - https://github.com/facebook/react-native/commit/f56d701e567af0c252a2e297bf81cd4add59378a

Unless there's reason to keep our current recommended TSConfig base pre-0.69

cc @radko93 @cortinico
