### PR TITLE
Force consistent casing in file names in React Native base

### DIFF
--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -17,6 +17,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "skipLibCheck": false
   },


### PR DESCRIPTION
It makes sense and comes with `tsc --init` v4.7.4

Also noted in bases
- recommended
- create-react-app
- vite-react
- node16
- node10
- node 18
- node 17
- node 12
- next