### PR TITLE
Support module resolution for package.json exports

### DIFF
--- a/bases/docusaurus.json
+++ b/bases/docusaurus.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "jsx": "react",
     "lib": ["DOM"],
+    "moduleResolution": "Node16",
     "noEmit": true,
     "types": ["node", "@docusaurus/module-type-aliases", "@docusaurus/theme-classic"],
     "baseUrl": ".",


### PR DESCRIPTION
@slorber @Josh-Cena I've noticed that there are packages (e.g. [@docusaurus/plugin-content-docs](https://github.com/facebook/docusaurus/blob/7489f8729aad4ae4c09219eb2980f87a72554c72/packages/docusaurus-plugin-content-docs/package.json#L7-L21)) that are using the NPM `exports` property. However, TypeScript isn't configured in a way that allows access to these items.

Given that Node 16.14 is required since [2.0.0-beta.21](https://github.com/facebook/docusaurus/releases/tag/v2.0.0-beta.21), I suggest that we can now add `"moduleResolution": "Node16"`.

This allows the compiler and IDE to gather the proper information for usings the items in `exports`.

