### PR TITLE
Introduce .gitattributes for better syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Treat all bases as 
+bases/*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
Per [the Linguist docs][docs], add an override for the bases so they get parsed and highlighted as JSON with Comments, rather than JSON, in line with the way Linguist [is configured for `tsconfig.json][config], so they don't look utterly terrible.

[docs]: https://github.com/github/linguist/blob/master/docs/overrides.md
[config]: https://github.com/github/linguist/blob/1fbaa41dc259695226bb4ffd70f43957df1b7fb6/lib/linguist/languages.yml#L3038

<details><summary>before this changes</summary>
<img width="1240" alt="Screen Shot 2022-09-13 at 11 45 56 AM" src="https://user-images.githubusercontent.com/2403023/189973706-f9a4052c-ed0e-47e6-9fb8-0dd832ad5a79.png">
</details>

<details><summary>with changes</summary>
<img width="1232" alt="Screen Shot 2022-09-13 at 11 44 43 AM" src="https://user-images.githubusercontent.com/2403023/189973517-ac0a5fb7-152f-4200-acd2-55dfaed82c33.png">
</details>