### PR TITLE
Update Next.js base to v13

### DIFF
--- a/bases/next.json
+++ b/bases/next.json
@@ -6,15 +6,20 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
-    "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This PR updates the TSConfig to match the default TSConfig generated by Next.js v13 (with `app` folder enabled): https://github.com/vercel/next.js/blob/e0b04f22e39eb7138c195fcaa4a35bc004bdaefb/packages/create-next-app/templates/experimental-app/tsconfig.json