### PR TITLE
Fix deploy script

### DIFF
--- a/scripts/deploy-changed-npm-packages.ts
+++ b/scripts/deploy-changed-npm-packages.ts
@@ -1,5 +1,5 @@
 import * as path from "https://deno.land/std/path/mod.ts";
-import * as bufio from "https://deno.land/std/io/bufio.ts";
+import * as bufio from "https://deno.land/std/io/buffer.ts";
 
 // Loop through generated packages, deploying versions for anything which has a different tsconfig
 const uploaded = []

--- a/scripts/generate-recommend.ts
+++ b/scripts/generate-recommend.ts
@@ -1,5 +1,5 @@
 import stripJsonComments from "https://esm.sh/strip-json-comments";
-import * as bufio from "https://deno.land/std/io/bufio.ts";
+import * as bufio from "https://deno.land/std/io/buffer.ts";
 import * as path from "https://deno.land/std/path/mod.ts";
 
 const tsconfigStorage = await Deno.makeTempDir({ prefix: "tsconfig" });


### PR DESCRIPTION
It looks like Deno's stdlib was restructured here: https://github.com/denoland/deno_std/pull/813.

Some files/modules were marked deprecated and re-exported parts of the new modules. In this case, `std/io/bufio.ts` was deprecated in favor of `std/io/buffer.ts`. As of `std@0.159.0`, `std/io/bufio.ts` was removed completely.

To prevent similar issues in the future, it would be best to pin to a specific version using one of the following:
- Versioned import i.e. `import * as bufio from "https://deno.land/std@1.58.0/io/bufio.ts"
- Importmap
- Lock file
- Vendoring i.e. `deno vendor`