### PR TITLE
rename the nodeLts files to node-lts

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,48 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/next/tsconfig.json"
 ```
+### Node LTS + ESM + Strictest <kbd><a href="./bases/node-lts-strictest-esm.combined.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/node-lts-strictest-esm
+yarn add --dev @tsconfig/node-lts-strictest-esm
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/node-lts-strictest-esm/tsconfig.json"
+```
+### Node LTS + Strictest <kbd><a href="./bases/node-lts-strictest.combined.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/node-lts-strictest
+yarn add --dev @tsconfig/node-lts-strictest
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/node-lts-strictest/tsconfig.json"
+```
+### Node LTS <kbd><a href="./bases/node-lts.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/node-lts
+yarn add --dev @tsconfig/node-lts
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/node-lts/tsconfig.json"
+```
 ### Node 10 <kbd><a href="./bases/node10.json">tsconfig.json</a></kbd>
 
 Install:
@@ -271,48 +313,6 @@ Add to your `tsconfig.json`:
 
 ```json
 "extends": "@tsconfig/node18/tsconfig.json"
-```
-### Node LTS + ESM + Strictest <kbd><a href="./bases/nodeLts-strictest-esm.combined.json">tsconfig.json</a></kbd>
-
-Install:
-
-```sh
-npm install --save-dev @tsconfig/nodeLts-strictest-esm
-yarn add --dev @tsconfig/nodeLts-strictest-esm
-```
-
-Add to your `tsconfig.json`:
-
-```json
-"extends": "@tsconfig/nodeLts-strictest-esm/tsconfig.json"
-```
-### Node LTS + Strictest <kbd><a href="./bases/nodeLts-strictest.combined.json">tsconfig.json</a></kbd>
-
-Install:
-
-```sh
-npm install --save-dev @tsconfig/nodeLts-strictest
-yarn add --dev @tsconfig/nodeLts-strictest
-```
-
-Add to your `tsconfig.json`:
-
-```json
-"extends": "@tsconfig/nodeLts-strictest/tsconfig.json"
-```
-### Node LTS <kbd><a href="./bases/nodeLts.json">tsconfig.json</a></kbd>
-
-Install:
-
-```sh
-npm install --save-dev @tsconfig/nodeLts
-yarn add --dev @tsconfig/nodeLts
-```
-
-Add to your `tsconfig.json`:
-
-```json
-"extends": "@tsconfig/nodeLts/tsconfig.json"
 ```
 ### Nuxt <kbd><a href="./bases/nuxt.json">tsconfig.json</a></kbd>
 

--- a/bases/node-lts-strictest-esm.combined.json
+++ b/bases/node-lts-strictest-esm.combined.json
@@ -3,7 +3,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node LTS + ESM + Strictest",
-  "_version": "18.12.0",
+  "_version": "18.12.1",
   "compilerOptions": {
     "lib": [
       "es2022"

--- a/bases/node-lts-strictest.combined.json
+++ b/bases/node-lts-strictest.combined.json
@@ -3,7 +3,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node LTS + Strictest",
-  "_version": "18.12.0",
+  "_version": "18.12.1",
   "compilerOptions": {
     "lib": [
       "es2022"

--- a/bases/node-lts.json
+++ b/bases/node-lts.json
@@ -3,7 +3,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node LTS",
-  "_version": "18.12.0",
+  "_version": "18.12.1",
   "compilerOptions": {
     "lib": [
       "es2022"

--- a/scripts/generate-lts.ts
+++ b/scripts/generate-lts.ts
@@ -1,4 +1,4 @@
-// deno run --allow-read --allow-write scripts/generate-combined.ts
+// deno run --allow-read --allow-write scripts/generate-lts.ts
 //
 
 interface NodeReleaseMetadata {
@@ -45,7 +45,7 @@ const lts = releasesJson
   );
 const baseMajorVersion = (lts.version.match(versionRegex) || [])[1];
 const base = `node${baseMajorVersion}`;
-const name = "nodeLts";
+const name = "node-lts";
 const versioned = {
   $schema: "https://json.schemastore.org/tsconfig",
   display: "Node LTS",


### PR DESCRIPTION
Due to package naming rules the nodeLts tsconfigs had to be renamed to node-lts. Please see the deploy failure [here](https://github.com/tsconfig/bases/actions/runs/3391252844/jobs/5636248749#step:6:32).