### PR TITLE
Enable `skipLibCheck` for React Native tsconfig

### DIFF
--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "React Native",
-  "_version": "2.0.0",
+  "_version": "2.0.3",
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
@@ -19,7 +19,7 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
-    "skipLibCheck": false
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
`skipLibCheck` makes it so that `tsc` will not typecheck library declarations. It was set in the previous TypeScript template, overriding the base @tsconfig/react-native, to avoid cases of duplicate identifiers between global types in React Native vs Node. I didn't enable it initially in the RN copy of the template since it reduces safety, didn't seem to cause issues in an example app, and wasn't the right place for the change compared to the base config.

In a more full repo I ran into the same issue. I was a bit confused, since specifying explicit `types` in `compilerOptions` would mean we are not brining it in for our own code. Telling tsc to ignore the Node types also isn't viable. Enabling `explainFiles`, I was able to see why it was being pulled in despite not being told to. In my specific case, a plain old JS Node script ended up being included during typechecking which imported a globbing library with `/// <reference types="node" />` in a declaration generated by the TypeScript compiler itself, which not only brought in the Node types being exported, but also created conflicts in the global namespace.

As a root cause we shouldn't be including a JS script targeting Node in the same tsconfig covering the React Native Project with RN types, but I expect it to be relatively common to have some JS scripts directory in an RN project that ends up falling under the typechecker includes, which would previously work. I was actually a bit surprised the file influenced typechecking since the script itself was not TypeScript.

This change would be automatically pulled in by the new RN template, as it is a patch release. Since the change is strictly more permissive, I think it makes sense to bump the patch version from 2.0.2 to 2.0.3 (the inline version field seems out of date?), but it is a decent behavior change, so I am open to feedback that it should be bumped differently.