### PR TITLE
Update docusaurus.json

### DIFF
--- a/bases/docusaurus.json
+++ b/bases/docusaurus.json
@@ -9,7 +9,7 @@
     "jsx": "react",
     "lib": ["DOM"],
     "noEmit": true,
-    "types": ["node", "@docusaurus/module-type-aliases", "@docusaurus/theme-classic"],
+    "types": ["node", "@docusaurus/module-type-aliases", "@docusaurus/preset-classic"],
     "baseUrl": ".",
     "paths": {
       "@site/*": ["./*"]


### PR DESCRIPTION
If you have installed @docusaurus/preset-classic, you don't need to install @docusaurus/theme-classic as a dependency.