### PR TITLE
Ember: default to `types: []`

### DIFF
--- a/bases/ember.json
+++ b/bases/ember.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Ember",
   "docs": "https://docs.ember-cli-typescript.com",
-  "_version": "1.1.0",
+  "_version": "2.0.0",
 
   // This is the base config used by Ember apps and addons. When actually used
   // via Ember CLI (e.g. ember-cli-typescript's blueprint), it additionally has
@@ -65,6 +65,12 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSourceMap": true,
-    "inlineSources": true
+    "inlineSources": true,
+
+    // Don't implicitly pull in declarations from `@types` packages unless we
+    // actually import from them AND the package in question doesn't bring its
+    // own types. You  may wish to override this e.g. with `"types": ["node"]`
+    // if your project has build-time elements that use NodeJS APIs.
+    "types": []
   }
 }


### PR DESCRIPTION
As the Ember ecosystem is slowly migrating from DefinitelyTyped to natively-bundled types, libraries that tests against "floating dependencies" (i.e. no lockfile) in CI are running into a fun situation where they get the latest version of e.g.`@ember/test-helpers` that has its own types, but the presence of the empty `@types/ember__test-helpers` package in their dependencies causes errors like:

```
error TS2688: Cannot find type definition file for 'ember__test-helpers'.
  The file is in the program because:
    Entry point for implicit type library 'ember__test-helpers'
```

In the scenario above, explicitly setting `types: []` prevents `@types/ember__test-helpers` from being loaded _iff_ `@ember/test-helpers` is shipping its own types.

This also prevents globals from packages like `@types/node` from being implicitly available, which is why I'm bumping the major here, but in practice it should be relatively uncommon for Ember projects to be relying on things like that.