### PR TITLE
Update Next base to match latest Next.js template

### DIFF
--- a/bases/next.json
+++ b/bases/next.json
@@ -17,6 +17,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": [".next/types/**/*.ts", "next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/bases/next.json
+++ b/bases/next.json
@@ -15,11 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  }
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/bases/next.json
+++ b/bases/next.json
@@ -15,8 +15,13 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": [".next/types/**/*.ts", "next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR updates the TSConfig to match the default TSConfig generated by Create Next App with the beta app folder enabled (`npx create-next-app --experimental-app`): https://github.com/vercel/next.js/blob/f0c7e72c7762740166a08e55af2e1d5b4961407b/packages/create-next-app/templates/app/ts/tsconfig.json