### PR TITLE
(fix) remove preserverValueImports from svelte.json

### DIFF
--- a/bases/svelte.json
+++ b/bases/svelte.json
@@ -11,11 +11,6 @@
       to enforce using `import type` instead of `import` for Types.
      */
     "verbatimModuleSyntax": true,
-    /**
-      TypeScript doesn't know about import usages in the template because it only sees the
-      script of a Svelte file. Therefore preserve all value imports. Requires TS 4.5 or higher.
-     */
-    "preserveValueImports": true,
     "isolatedModules": true,
     /**
       To have warnings/errors of the Svelte compiler at the correct position,


### PR DESCRIPTION
It's deprecated, too
Leftover from #161