### PR TITLE
Add `es2023` to Node 18

### DIFF
--- a/bases/node18.json
+++ b/bases/node18.json
@@ -3,7 +3,7 @@
   "display": "Node 18",
 
   "compilerOptions": {
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "module": "commonjs",
     "target": "es2022",
 


### PR DESCRIPTION
According to node.green[^1] Node 18 supports ES2023 array features.

[^1]: https://node.green/#ES2023