### PR TITLE
[react-native] Update list of suported libs

### DIFF
--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -1,13 +1,25 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "React Native",
-  "_version": "2.0.3",
+  "_version": "3.0.0",
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
     "types": ["react-native", "jest"],
     "lib": [
-      "es2019"
+      "es2019",
+      "es2020.bigint",
+      "es2020.date",
+      "es2020.number",
+      "es2020.promise",
+      "es2020.string",
+      "es2020.symbol.wellknown",
+      "es2021.promise",
+      "es2021.string",
+      "es2021.weakref",
+      "es2022.array",
+      "es2022.object",
+      "es2022.string"
     ],
     "allowJs": true,
     "jsx": "react-native",


### PR DESCRIPTION
The tsconfig already supports esnext syntax, but RN supports some newer libraries than the es2019 target.   This adds the libs where the types declared are implemented by Hermes as of current main branch (found via code search or internal searches) or an RN polypill (like for promise).

  I bumped the major here, so users on older versions of RN don’t get the new libs showing up as supported without explicitly updating. This will be accompanied by a change which bumps the version in our own template.