### PR TITLE
Move `verbatimModuleSyntax` from strictest to ESM

### DIFF
--- a/bases/esm.json
+++ b/bases/esm.json
@@ -3,6 +3,8 @@
   "display": "ESM",
 
   "compilerOptions": {
-    "module": "es2022"
+    "module": "es2022",
+
+    "verbatimModuleSyntax": true
   }
 }

--- a/bases/strictest.json
+++ b/bases/strictest.json
@@ -12,7 +12,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
 
-    "verbatimModuleSyntax": true,
     "checkJs": true,
 
     "esModuleInterop": true,


### PR DESCRIPTION
Fixes #168 by moving the `verbatimModuleSyntax: true` option from strictest to ESM, ensuring that strictest can be using with CommonJS projects