### PR TITLE
Node19 base

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,20 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/node18/tsconfig.json"
 ```
+### Node 19 <kbd><a href="./bases/node19.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/node19
+yarn add --dev @tsconfig/node19
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/node19/tsconfig.json"
+```
 ### Node 20 <kbd><a href="./bases/node20.json">tsconfig.json</a></kbd>
 
 Install:

--- a/bases/node19.json
+++ b/bases/node19.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 19",
+
+  "compilerOptions": {
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "target": "es2022",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
Closes #142 

## Node 19 base

After examination of https://node.green/ I found out that Node 19 capabilities are equal to Node 18.

### Version 1

Due to this issue: https://github.com/tsconfig/bases/issues/173 I'm making the version 1 first, having `"lib": ["es2022"]`, in order to support Typescript below version 5.
After that version 2 can be released similar to what Node 18 base looks like currently (having es2023 lib).


