### PR TITLE
Add "tsc --showConfig" command to combine section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ to start from a Node 18 + Strictest base config, you can install both
 }
 ```
 
+You can see the result of the combined configs via `tsc --showConfig`.
+
 ### Contributing
 
 ```sh


### PR DESCRIPTION
I think it is very useful with combined configurations to see the resulting outcome. Therefore, a reference to the necessary command for the TypeScript compiler should not be missing.