### PR TITLE
Node 19 base v2

### DIFF
--- a/bases/node19.json
+++ b/bases/node19.json
@@ -2,8 +2,10 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node 19",
 
+  "_version": "2.0.0",
+
   "compilerOptions": {
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "module": "commonjs",
     "target": "es2022",
 


### PR DESCRIPTION
### Version 2

with `es2023` lib (similar to Node 18 base v2).