### PR TITLE
Update nuxt.json: Add .nuxt, dist to "exclude" to match create-nuxt-app.

### DIFF
--- a/bases/nuxt.json
+++ b/bases/nuxt.json
@@ -31,6 +31,8 @@
     ]
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    ".nuxt", 
+    "dist"
   ]
 }


### PR DESCRIPTION
## Overview
In the tsconfig generated by the create-nuxt-app repository, .nuxt and dist were also "excluded".
I thought this could be included in the common settings when using Nuxt.js.

## Related links
https://github.com/nuxt/create-nuxt-app/blob/c4680b0018edefdd5de0a771858faa83c7d43b37/packages/cna-template/template/tsconfig.json