### PR TITLE
Added tsParticles base tsconfig, used on all plugins and presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 packages/
+.idea/

--- a/bases/tsparticles.json
+++ b/bases/tsparticles.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "tsParticles",
+  "_version": "1.0.0",
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": [
+      "ESNext",
+      "ES2022",
+      "ES2021",
+      "ES2020",
+      "ES2019",
+      "ES2018",
+      "ES2017",
+      "ES2016",
+      "ES2015",
+      "DOM"
+    ],
+    "types": [
+      "node"
+    ],
+    "allowJs": true,
+    "declaration": false,
+    "removeComments": true,
+    "importHelpers": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "alwaysStrict": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## tsParticles

Added the base tsconfig used by all [tsParticles](https://github.com/tsparticles) packages. It's the same config used in the `@tsparticles/tsconfig` package, but I think the base config could fit here and be moved away from there.

The actual base config can be found [here](https://github.com/tsparticles/utils/blob/main/packages/tsconfig/tsconfig.base.json)