### PR TITLE
Use `moduleResolution: bundler` for Vite React

### DIFF
--- a/bases/vite-react.json
+++ b/bases/vite-react.json
@@ -12,7 +12,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/bases/vite-react.json
+++ b/bases/vite-react.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Vite React",
+  "_version": "2.0.0",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,


### PR DESCRIPTION
In the [Announcing Typescript 5.0](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#moduleresolution-bundler) blogpost, the Typescript team introduced the `moduleResolution: bundler` option.  
They say:
> If you are using a modern bundler like Vite, esbuild, swc, Webpack, Parcel, and others that implement a hybrid lookup strategy, the new bundler option should be a good fit for you.

This PR changes `moduleResolution` to the new strategy for the Vite React base.  
Please let me know if this change is also applicable to any other bases, then I will edit those as well.