### PR TITLE
[react-native] `moduleResolution: "nodenext"`

### DIFF
--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "React Native",
-  "_version": "3.0.0",
+  "_version": "3.0.1",
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
@@ -29,7 +29,7 @@
     "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
+    "forceConsistentCasingInFileNames": false,
     "esModuleInterop": true,
     "skipLibCheck": true
   },

--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -26,7 +26,7 @@
     "noEmit": true,
     "isolatedModules": true,
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This lets TypeScript do ESM style resolution, including export maps, like:
```
exports: {
  "foo": "src/foo.js",
  "bar": "src/bar.js",
}
```

An out of the box typechecking in the RN TypeScript template will still resolve `node` instead of `react-native` or `default`, which isn't quite right, but this unblocks usage which isn't platform-specific, or cases where different platforms have the same types.

When RN starts targeting 5.0 we should consider changing it to `moduleResolution: "bundler"` and customizing the resolution behavior more in the RN template.

The version we ship this in (and whether we need to bump major again) depends on if we want to enable this for 0.72 vs 0.73.