### PR TITLE
Move back to "moduleResolution: node"

### DIFF
--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "React Native",
-  "_version": "3.0.1",
+  "_version": "3.0.2",
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
@@ -26,7 +26,7 @@
     "noEmit": true,
     "isolatedModules": true,
     "strict": true,
-    "moduleResolution": "nodenext",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": false,


### PR DESCRIPTION
We probably don't want this in 0.72 yet, since Metro won't work with this by default yet, and `moduleResolution: bundler` is better and slated to come to 0.73.