### PR TITLE
Enable strict mode for svelte.json

### DIFF
--- a/bases/svelte.json
+++ b/bases/svelte.json
@@ -17,7 +17,7 @@
      */
     "sourceMap": true,
 
-    "strict": false,
+    "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true

--- a/bases/svelte.json
+++ b/bases/svelte.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Svelte",
-  "_version": "4.0.0",
+  "_version": "5.0.0",
 
   "compilerOptions": {
     "moduleResolution": "node",


### PR DESCRIPTION
Strict mode is enabled in pretty much all other bases, and also SvelteKit. Seems like something that would make sense to enable here too

@dummdidumm 