### PR TITLE
add bun tsconfig base

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/recommended/tsconfig.json"
 ```
+### Bun <kbd><a href="./bases/bun.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/bun
+yarn add --dev @tsconfig/bun
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/bun/tsconfig.json"
+```
 ### Create React App <kbd><a href="./bases/create-react-app.json">tsconfig.json</a></kbd>
 
 Install:

--- a/bases/bun.json
+++ b/bases/bun.json
@@ -1,0 +1,29 @@
+{
+  // This is based on https://bun.sh/docs/runtime/typescript#recommended-compileroptions
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Bun",
+  "docs": "https://bun.sh/docs/runtime/typescript",
+  "compilerOptions": {
+    // add Bun type definitions
+    "types": [
+      "bun-types"
+    ],
+    // enable latest features
+    "lib": [
+      "ESNext"
+    ],
+    "module": "ESNext",
+    "target": "ESNext",
+    // if TS 5.x+
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "moduleDetection": "force",
+    // support JSX
+    "jsx": "react-jsx",
+    // best practices
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}

--- a/bases/bun.json
+++ b/bases/bun.json
@@ -3,24 +3,29 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Bun",
   "docs": "https://bun.sh/docs/runtime/typescript",
+
   "compilerOptions": {
     // add Bun type definitions
     "types": [
       "bun-types"
     ],
+
     // enable latest features
     "lib": [
       "ESNext"
     ],
     "module": "ESNext",
     "target": "ESNext",
+
     // if TS 5.x+
     "moduleResolution": "bundler",
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "moduleDetection": "force",
+
     // support JSX
     "jsx": "react-jsx",
+
     // best practices
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Self explanatory, adds a base config for https://bun.sh borrowing the recommended config from [the documentation](https://bun.sh/docs/runtime/typescript#recommended-compileroptions)