### PR TITLE
fix: set `allowJs` for `checkJs `

### DIFF
--- a/bases/strictest.json
+++ b/bases/strictest.json
@@ -12,6 +12,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
 
+    "allowJs": true,
     "checkJs": true,
 
     "esModuleInterop": true,


### PR DESCRIPTION
Currently `bases/strictest.json` has `checkJs: true`, but doesn't have `allowJs: true` and `checkJs` doesn't work.

https://github.com/microsoft/TypeScript/issues/21435#issuecomment-361757612
> --checkJs really means nothing without --allowJs