### PR TITLE
Ember: set verbatimModuleSyntax: true

### DIFF
--- a/bases/ember.json
+++ b/bases/ember.json
@@ -12,6 +12,10 @@
     "module": "esnext",
     "moduleResolution": "bundler",
 
+    // We don't want to include types dependencies in our compiled output, so tell TypeScript
+    // to enforce using `import type` instead of `import` for Types.
+    "verbatimModuleSyntax": true,
+
     // Trying to check Ember apps and addons with `allowJs: true` is a recipe
     // for many unresolveable type errors, because with *considerable* extra
     // configuration it ends up including many files which are *not* valid and


### PR DESCRIPTION
This is a breaking change for consumers of `@tsconfig/ember`, as they'll receive errors if they were not previously enforcing `import type` for type-imports.

Context:
- Already used in Ember's library blueprint: https://github.com/embroider-build/addon-blueprint/blob/main/files/__addonLocation__/tsconfig.json
- Already used in Svelte: https://github.com/tsconfig/bases/blob/main/bases/svelte.json#L14

The problem being solved here:
- https://github.com/emberjs/babel-plugin-ember-template-compilation/pull/30
  - Another repro: https://github.com/ember-template-imports/ember-template-imports/issues/207
  - An option we have for solving these issues is to combine [`onlyRemoveTypeImports`](https://github.com/embroider-build/addon-blueprint/blob/main/files/__addonLocation__/babel.config.json#L3) and setting `verbatimModuleSyntax: true`. 
  - Discord disco: https://discord.com/channels/480462759797063690/568935504288940056/1166059161369460797