### PR TITLE
Update Next.js to match the latest template (v14)

### DIFF
--- a/bases/next.json
+++ b/bases/next.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Next.js",
-  "_version": "2.0.0",
+  "_version": "3.0.0",
 
   "compilerOptions": {
+    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
-    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
@@ -21,7 +21,10 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/bases/next.json
+++ b/bases/next.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Next.js",
-  "_version": "4.0.0",
+  "_version": "3.0.0",
 
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/bases/next.json
+++ b/bases/next.json
@@ -1,10 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Next.js",
-  "_version": "3.0.0",
+  "_version": "4.0.0",
 
   "compilerOptions": {
-    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -25,7 +24,5 @@
     "paths": {
       "@/*": ["./*"]
     }
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  }
 }


### PR DESCRIPTION
This PR updates the Next.js base to match the default TSConfig generated by Create Next App.

https://github.com/vercel/next.js/blob/v14.0.0/packages/create-next-app/templates/app/ts/tsconfig.json

As per https://github.com/tsconfig/bases/issues/207 I removed `include` and `exclude` fields.

I've also set the base `_version` to `3.0.0`.