### PR TITLE
Support Node 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,20 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/node20/tsconfig.json"
 ```
+### Node 21 <kbd><a href="./bases/node21.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/node21
+yarn add --dev @tsconfig/node21
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/node21/tsconfig.json"
+```
 ### Nuxt <kbd><a href="./bases/nuxt.json">tsconfig.json</a></kbd>
 
 Install:

--- a/bases/node21.json
+++ b/bases/node21.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 21",
+  "_version": "21.0.0",
+
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "module": "node16",
+    "target": "es2023",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node16"
+  }
+}

--- a/bases/node21.json
+++ b/bases/node21.json
@@ -6,7 +6,7 @@
   "compilerOptions": {
     "lib": ["es2023"],
     "module": "node16",
-    "target": "es2023",
+    "target": "es2022",
 
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Modeled after #171, this adds support for Node21.
 
Side-note, I checked [node.green](https://node.green), and found that Node.js 18.18.2, 19, and 20 all support ES2023. Should I update `"target"` of our corresponding presets to `es2023` to match that, now that the value is supported by the latest TypeScript version?

Closes #231
Closes #209 (already fixed by #210)