### PR TITLE
chore: remove `bun-types` (in favor of `@types/bun`)

### DIFF
--- a/bases/bun.json
+++ b/bases/bun.json
@@ -5,11 +5,6 @@
   "docs": "https://bun.sh/docs/runtime/typescript",
 
   "compilerOptions": {
-    // add Bun type definitions
-    "types": [
-      "bun-types"
-    ],
-
     // enable latest features
     "lib": [
       "ESNext"


### PR DESCRIPTION
With bun `1.0.19`, types now lives in `@types/bun`, removing the need for `bun-types`.

Refs: https://bun.sh/blog/bun-v1.0.19#re-introducing-types-bun-formerly-bun-types