### PR TITLE
Add `baseUrl` notices to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/docusaurus/tsconfig.json"
 ```
+
+> **NOTE**: You may need to add `"baseUrl": "."` to your `tsconfig.json` to support proper file resolution.
 ### Ember <kbd><a href="./bases/ember.json">tsconfig.json</a></kbd>
 
 Install:
@@ -136,6 +138,8 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/ember/tsconfig.json"
 ```
+
+> **NOTE**: You may need to add `"baseUrl": "."` to your `tsconfig.json` to support proper file resolution.
 ### Next.js <kbd><a href="./bases/next.json">tsconfig.json</a></kbd>
 
 Install:
@@ -304,6 +308,8 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/nuxt/tsconfig.json"
 ```
+
+> **NOTE**: You may need to add `"baseUrl": "."` to your `tsconfig.json` to support proper file resolution.
 ### React Native <kbd><a href="./bases/react-native.json">tsconfig.json</a></kbd>
 
 Install:
@@ -332,6 +338,8 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/remix/tsconfig.json"
 ```
+
+> **NOTE**: You may need to add `"baseUrl": "."` to your `tsconfig.json` to support proper file resolution.
 ### Strictest <kbd><a href="./bases/strictest.json">tsconfig.json</a></kbd>
 
 Install:

--- a/readme-extras/docusaurus.md
+++ b/readme-extras/docusaurus.md
@@ -1,0 +1,1 @@
+> **NOTE**: You may need to add `"baseUrl": "."` to your `tsconfig.json` to support proper file resolution.

--- a/readme-extras/ember.md
+++ b/readme-extras/ember.md
@@ -1,0 +1,1 @@
+> **NOTE**: You may need to add `"baseUrl": "."` to your `tsconfig.json` to support proper file resolution.

--- a/readme-extras/nuxt.md
+++ b/readme-extras/nuxt.md
@@ -1,0 +1,1 @@
+> **NOTE**: You may need to add `"baseUrl": "."` to your `tsconfig.json` to support proper file resolution.

--- a/readme-extras/remix.md
+++ b/readme-extras/remix.md
@@ -1,0 +1,1 @@
+> **NOTE**: You may need to add `"baseUrl": "."` to your `tsconfig.json` to support proper file resolution.


### PR DESCRIPTION
This updates the documentation to add a notice that `baseUrl` may need to be set manually, for places where it is relevant.

But, checking the docs for [baseUrl](https://www.typescriptlang.org/tsconfig#baseUrl), it seems that it is only recommended for use with AMD module loaders (since TypeScript 4.1, it is no longer required when using 'paths`). So, I'm thinking it might be better just to remove the properties all together (with no documentation update)? That will still address the "confusion" from the linked issue, and not add "notices" that do not apply for most people.

Closes #223