### PR TITLE
[Ember] set "target" to ESNext

### DIFF
--- a/bases/ember.json
+++ b/bases/ember.json
@@ -8,7 +8,7 @@
   // via Ember CLI (e.g. ember-cli-typescript's blueprint), it additionally has
   // `compilerOptions.baseUrl`, `compilerOptions.paths`, and `include` set.
   "compilerOptions": {
-    "target": "es2021",
+    "target": "ESNext",
     "module": "esnext",
     "moduleResolution": "bundler",
 


### PR DESCRIPTION
I noticed in a project I didn't have access to [Array.prototype.toSpliced](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced), which landed in TS 5.2, so this should help others with that problem.