### PR TITLE
Update @tsconfig/bun to reflect changes on bun docs

### DIFF
--- a/bases/bun.json
+++ b/bases/bun.json
@@ -1,29 +1,32 @@
 {
-  // This is based on https://bun.sh/docs/runtime/typescript#recommended-compileroptions
+  // This is based on https://bun.sh/docs/typescript#suggested-compileroptions
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Bun",
-  "docs": "https://bun.sh/docs/runtime/typescript",
+  "docs": "https://bun.sh/docs/typescript",
 
   "compilerOptions": {
-    // enable latest features
-    "lib": [
-      "ESNext"
-    ],
-    "module": "esnext",
-    "target": "esnext",
-
-    // if TS 5.x+
-    "moduleResolution": "bundler",
-    "noEmit": true,
-    "allowImportingTsExtensions": true,
+    // Enable latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
     "moduleDetection": "force",
-
-    // support JSX
     "jsx": "react-jsx",
+    "allowJs": true,
 
-    // best practices
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
     "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Some stricter flags
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noPropertyAccessFromIndexSignature": true
   }
 }


### PR DESCRIPTION
This PR updates `@tsconfig/bun` to reflect changes on bun docs.

The changes are made recently to remove redundant options and fix inconsistency between docs and the generated `tsconfig.json` by the `bun init` command.
https://github.com/oven-sh/bun/pull/8654, https://github.com/oven-sh/bun/pull/8953

The tsconfig is based on https://bun.sh/docs/typescript#suggested-compileroptions.

I'm not sure we should include the stricter flags (`noUnusedLocals`, `noUnusedParameters`, `noPropertyAccessFromIndexSignature`) which are disabled by default in `bun init`, because we can enable them by the combination of `@tsconfig/bun` and `@tsconfig/strictest`.
ref: [`tsconfig-for-init.json`](https://github.com/oven-sh/bun/blob/main/src/cli/tsconfig-for-init.json)
