### PR TITLE
[Ember]: Set noEmitOnError to false

### DIFF
--- a/bases/ember.json
+++ b/bases/ember.json
@@ -48,10 +48,13 @@
     "noPropertyAccessFromIndexSignature": true,
 
     // --- Compilation/integration settings
-    // Setting `noEmitOnError` here allows ember-cli-typescript to catch errors
-    // and inject them into Ember CLI's build error reporting, which provides
-    // nice feedback for when
-    "noEmitOnError": true,
+    // Setting `noEmitOnError` here allows tools trying to respect the tsconfig
+    // to still emit code without breaking on errors.
+    // Errors are still reported in the CLI when running `tsc` or `glint`,
+    // but the errors won't prevent code from being emitted.
+    // This helps hasten development by allowing devs to prototype before coming
+    // to a decision on what they want their types to be.
+    "noEmitOnError": false,
 
     // We use Babel for emitting runtime code, because it's very important that
     // we always and only use the same transpiler for non-stable features, in


### PR DESCRIPTION
Reasons for doing this:
- we no longer use `ember-cli-typescript` and recommend _against_ its usage in new projects (the comment in the tsconfig.json here mentioned that the setting for `true` was to have ember-cli's error reporting screen pick up on type errors)
- `noEmitOnError` can break tools in silent ways, including `Glint`
  - See:
    - https://www.typescriptlang.org/tsconfig#noEmitOnError
      > This defaults to false, making it easier to work with TypeScript in a watch-like environment where you may want to see results of changes to your code in another environment before making sure all errors are resolved. 
    - https://github.com/typed-ember/glint/issues/599#issuecomment-1828191524
      this is likely a bug in Glint, but people generally want to try out code rather than have the type-checker block them
    - https://github.com/microsoft/TypeScript/issues/54305
      - Which could be a good time to bring up that libraries are using `@tsconfig/ember` to emit declarations, so I think this config should be optimized around declaration emit (but not enable it by default, so we still have a good experience for app devs) 
- type-checking JS/TS is more treated as a lint these days, rather than compiled code, like Rust
  - additionally, it's usually ok to craft specific lies in certain situations, which other languages don't allow you to do (maybe due to limitations of TS, a library, many reasons)
 

Other tools that behave similar:
- CLI tools that compile TS and don't block you when you have an error  
  - Vite
  - Vitest
  - Bun
  - ESBuild
  - SWC
  - Rollup (depending on your plugins (using babel, or _just not tsc_ for example)

cc @wagenet @gitKrystan @simonihmig