### PR TITLE
Remove `forceConsistentCasingInFileNames`

### DIFF
--- a/bases/create-react-app.json
+++ b/bases/create-react-app.json
@@ -12,7 +12,6 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "noEmit": true,

--- a/bases/next.json
+++ b/bases/next.json
@@ -8,7 +8,6 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
-    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",

--- a/bases/node-lts.json
+++ b/bases/node-lts.json
@@ -13,7 +13,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16"
   }
 }

--- a/bases/node10.json
+++ b/bases/node10.json
@@ -10,7 +10,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node"
   }
 }

--- a/bases/node12.json
+++ b/bases/node12.json
@@ -11,7 +11,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16"
   }
 }

--- a/bases/node14.json
+++ b/bases/node14.json
@@ -11,7 +11,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16"
   }
 }

--- a/bases/node16.json
+++ b/bases/node16.json
@@ -11,7 +11,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16"
   }
 }

--- a/bases/node17.json
+++ b/bases/node17.json
@@ -10,7 +10,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "useDefineForClassFields": true,
     "moduleResolution": "node16"
   }

--- a/bases/node18.json
+++ b/bases/node18.json
@@ -12,7 +12,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16"
   }
 }

--- a/bases/node19.json
+++ b/bases/node19.json
@@ -12,7 +12,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16"
   }
 }

--- a/bases/node20.json
+++ b/bases/node20.json
@@ -11,7 +11,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16"
   }
 }

--- a/bases/node21.json
+++ b/bases/node21.json
@@ -11,7 +11,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16"
   }
 }

--- a/bases/react-native.json
+++ b/bases/react-native.json
@@ -29,7 +29,6 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": false,
     "esModuleInterop": true,
     "skipLibCheck": true
   }

--- a/bases/remix.json
+++ b/bases/remix.json
@@ -14,7 +14,6 @@
     "target": "es2019",
     "strict": true,
     "allowJs": true,
-    "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]

--- a/bases/strictest.json
+++ b/bases/strictest.json
@@ -17,8 +17,7 @@
     "checkJs": true,
 
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "skipLibCheck": true
   },
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Strictest",

--- a/bases/svelte.json
+++ b/bases/svelte.json
@@ -20,7 +20,6 @@
 
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Remove all `forceConsistentCasingInFileNames`. The default value is `true` since TypeScript 5.0 . And it will be deprecated later.

Only `@tsconfig/recommended` keep `forceConsistentCasingInFileNames` (although personally I think it should be removed).

Refer this issue and comment: https://github.com/microsoft/TypeScript/issues/51909#issuecomment-1385124052
