### PR TITLE
fix: sync `target` and `lib`

### DIFF
--- a/bases/node-lts.json
+++ b/bases/node-lts.json
@@ -9,7 +9,7 @@
       "es2023"
     ],
     "module": "node16",
-    "target": "es2022",
+    "target": "es2023",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bases/node18.json
+++ b/bases/node18.json
@@ -5,7 +5,7 @@
   "_version": "18.2.0",
 
   "compilerOptions": {
-    "lib": ["es2023"],
+    "lib": ["es2022"],
     "module": "node16",
     "target": "es2022",
 

--- a/bases/node19.json
+++ b/bases/node19.json
@@ -5,7 +5,7 @@
   "_version": "19.1.0",
 
   "compilerOptions": {
-    "lib": ["es2023"],
+    "lib": ["es2022"],
     "module": "node16",
     "target": "es2022",
 

--- a/bases/node20.json
+++ b/bases/node20.json
@@ -6,7 +6,7 @@
   "compilerOptions": {
     "lib": ["es2023"],
     "module": "node16",
-    "target": "es2022",
+    "target": "es2023",
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node21.json
+++ b/bases/node21.json
@@ -6,7 +6,7 @@
   "compilerOptions": {
     "lib": ["es2023"],
     "module": "node16",
-    "target": "es2022",
+    "target": "es2023",
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node22.json
+++ b/bases/node22.json
@@ -6,7 +6,7 @@
   "compilerOptions": {
     "lib": ["es2023"],
     "module": "node16",
-    "target": "es2022",
+    "target": "es2023",
 
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
1. See https://github.com/tsconfig/bases/issues/271#issuecomment-2182656647, TS 5.5 now support es2023 target.
2. Node18 and Node19 will not support some features of es2023. Therefore, Node18 and Node19's `lib` should be es2022.

Closes #217.