### PR TITLE
Support Node 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,20 @@ Add to your `tsconfig.json`:
 ```json
 "extends": "@tsconfig/node22/tsconfig.json"
 ```
+### Node 23 <kbd><a href="./bases/node23.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/node23
+yarn add --dev @tsconfig/node23
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/node23/tsconfig.json"
+```
 ### Nuxt <kbd><a href="./bases/nuxt.json">tsconfig.json</a></kbd>
 
 Install:

--- a/bases/node23.json
+++ b/bases/node23.json
@@ -6,7 +6,7 @@
   "compilerOptions": {
     "lib": ["es2024"],
     "module": "node16",
-    "target": "es2022",
+    "target": "es2024",
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node23.json
+++ b/bases/node23.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 23",
+  "_version": "23.0.0",
+
+  "compilerOptions": {
+    "lib": ["es2024"],
+    "module": "node16",
+    "target": "es2022",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node16"
+  }
+}


### PR DESCRIPTION
Node.js 23 was published on 2024-10-16 https://nodejs.org/en/blog/release/v23.0.0