### PR TITLE
Enable lib for Array.fromAsync and Iterator helpers

### DIFF
--- a/bases/node22.json
+++ b/bases/node22.json
@@ -4,7 +4,7 @@
   "_version": "22.0.0",
 
   "compilerOptions": {
-    "lib": ["es2023"],
+    "lib": ["es2023", "esnext.iterator", "esnext.array"],
     "module": "node16",
     "target": "es2022",
 


### PR DESCRIPTION
Node 22 supports Iterator Helpers and Array.fromAsync  but these types are defined in esnext. This Pull Request enables those individual library components.

https://nodejs.org/en/blog/announcements/v22-release-announce