### PR TITLE
fix: Remove vite-react tsBuildInfo path override

### DIFF
--- a/bases/vite-react.json
+++ b/bases/vite-react.json
@@ -4,7 +4,6 @@
   "_version": "3.4.0",
 
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
Remove the tsBuildInfo path override for `vite-react`. Having the tsBuildInfo in `node_modules` complicates CI (requires full wipe of `node_modules`, or specific wipe of the tsbuildinfo) and obfuscates the build process. It would also point multiple typescript projects to the same tsBuildInfo in a monorepo configuration.