### PR TITLE
feat(strictest): enable `verbatimModuleSyntax`

### DIFF
--- a/bases/strictest.json
+++ b/bases/strictest.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
 
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
 
     "checkJs": true,
 


### PR DESCRIPTION
This PR enables `verbatimModuleSyntax` for `strictest.json`.

The `isolatedModules` option has been removed because it is enabled by default when `verbatimModuleSyntax` is enabled.

This option used to be enabled in `esm.json`, but that config has been deleted.

Here is the history of `verbatimModuleSyntax`:
- [Use new `verbatimModuleSyntax` setting for TS v5](https://github.com/tsconfig/bases/commit/00fa4eeb82d0cd700df26ba5f7e0ec011781adb1)
- [Move `verbatimModuleSyntax` from strictest to ESM](https://github.com/tsconfig/bases/commit/f674fa6cbca17062ff02511b02872f8729a597ec)
- [Remove the esm json file completly](https://github.com/tsconfig/bases/commit/8c9ae60cf299d8f550661c1aa9cc9abdfa1dc1fe)