### PR TITLE
Add QJSEngine config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ We target the latest stable version of TypeScript, note that because we want to 
 | [Node 22](#node-22-tsconfigjson)                   | [`@tsconfig/node22`](https://npmjs.com/package/@tsconfig/node22)                     |
 | [Node 23](#node-23-tsconfigjson)                   | [`@tsconfig/node23`](https://npmjs.com/package/@tsconfig/node23)                     |
 | [Nuxt](#nuxt-tsconfigjson)                         | [`@tsconfig/nuxt`](https://npmjs.com/package/@tsconfig/nuxt)                         |
+| [QJSEngine](#qjsengine-tsconfigjson)               | [`@tsconfig/nuxt`](https://npmjs.com/package/@tsconfig/qtsengine)                    |
 | [React Native](#react-native-tsconfigjson)         | [`@tsconfig/react-native`](https://npmjs.com/package/@tsconfig/react-native)         |
 | [Remix](#remix-tsconfigjson)                       | [`@tsconfig/remix`](https://npmjs.com/package/@tsconfig/remix)                       |
 | [Strictest](#strictest-tsconfigjson)               | [`@tsconfig/strictest`](https://npmjs.com/package/@tsconfig/strictest)               |
@@ -340,6 +341,20 @@ Add to your `tsconfig.json`:
 ```
 
 > **NOTE**: You may need to add `"baseUrl": "."` to your `tsconfig.json` to support proper file resolution.
+### QJSEngine <kbd><a href="./bases/qjsengine.json">tsconfig.json</a></kbd>
+
+Install:
+
+```sh
+npm install --save-dev @tsconfig/qjsengine
+yarn add --dev @tsconfig/qjsengine
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@tsconfig/qjsengine/tsconfig.json"
+```
 ### React Native <kbd><a href="./bases/react-native.json">tsconfig.json</a></kbd>
 
 Install:

--- a/bases/qjsengine.json
+++ b/bases/qjsengine.json
@@ -1,0 +1,17 @@
+{
+	// https://doc.qt.io/qt-5/qjsengine.html
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "QJSEngine",
+
+  "compilerOptions": {
+    // Technically QTJSEngine supportes ES2016, however there are issues with
+    // arrow functions where in certain contexts "this" does not exist.
+    // Targeting ES5 instead fixes these issues by binding this to a variable
+    // and closing over that instead.
+    "target": "ES5",
+    "lib": ["ES2016"],
+    "module": "none",
+    "esModuleInterop": false,
+    "strict": true
+  }
+}


### PR DESCRIPTION
This adds a config for targeting [QJSEngine](https://doc.qt.io/qt-5/qjsengine.html) an implementation of ES2016 (with some caveats) that Qt uses. In particular this is used by programs such as the [Mixxx](https://mixxx.org/) DJ software to allow plugin development with JavaScript.