### PR TITLE
Update table to include Node with TypeScript, fix LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,36 +7,37 @@ We target the latest stable version of TypeScript, note that because we want to 
 
 ### Table of TSConfigs
 
-| Name                                               | Package                                                                              |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Recommended](#recommended-tsconfigjson)           | [`@tsconfig/recommended`](https://npmjs.com/package/@tsconfig/recommended)           |
-| [Bun](#bun-tsconfigjson)                           | [`@tsconfig/bun`](https://npmjs.com/package/@tsconfig/bun)                           |
-| [Create React App](#create-react-app-tsconfigjson) | [`@tsconfig/create-react-app`](https://npmjs.com/package/@tsconfig/create-react-app) |
-| [Cypress](#cypress-tsconfigjson)                   | [`@tsconfig/cypress`](https://npmjs.com/package/@tsconfig/cypress)                   |
-| [Deno](#deno-tsconfigjson)                         | [`@tsconfig/deno`](https://npmjs.com/package/@tsconfig/deno)                         |
-| [Docusaurus v2](#docusaurus-v2-tsconfigjson)       | [`@tsconfig/docusaurus`](https://npmjs.com/package/@tsconfig/docusaurus)             |
-| [Ember](#ember-tsconfigjson)                       | [`@tsconfig/ember`](https://npmjs.com/package/@tsconfig/ember)                       |
-| [Next.js](#nextjs-tsconfigjson)                    | [`@tsconfig/next`](https://npmjs.com/package/@tsconfig/next)                         |
-| [Node LTS](#node-lts-tsconfigjson)                 | [`@tsconfig/node-lts`](https://npmjs.com/package/@tsconfig/node-lts)                 |
-| [Node 10](#node-10-tsconfigjson)                   | [`@tsconfig/node10`](https://npmjs.com/package/@tsconfig/node10)                     |
-| [Node 12](#node-12-tsconfigjson)                   | [`@tsconfig/node12`](https://npmjs.com/package/@tsconfig/node12)                     |
-| [Node 14](#node-14-tsconfigjson)                   | [`@tsconfig/node14`](https://npmjs.com/package/@tsconfig/node14)                     |
-| [Node 16](#node-16-tsconfigjson)                   | [`@tsconfig/node16`](https://npmjs.com/package/@tsconfig/node16)                     |
-| [Node 17](#node-17-tsconfigjson)                   | [`@tsconfig/node17`](https://npmjs.com/package/@tsconfig/node17)                     |
-| [Node 18](#node-18-tsconfigjson)                   | [`@tsconfig/node18`](https://npmjs.com/package/@tsconfig/node18)                     |
-| [Node 19](#node-19-tsconfigjson)                   | [`@tsconfig/node19`](https://npmjs.com/package/@tsconfig/node19)                     |
-| [Node 20](#node-20-tsconfigjson)                   | [`@tsconfig/node20`](https://npmjs.com/package/@tsconfig/node20)                     |
-| [Node 21](#node-21-tsconfigjson)                   | [`@tsconfig/node21`](https://npmjs.com/package/@tsconfig/node21)                     |
-| [Node 22](#node-22-tsconfigjson)                   | [`@tsconfig/node22`](https://npmjs.com/package/@tsconfig/node22)                     |
-| [Node 23](#node-23-tsconfigjson)                   | [`@tsconfig/node23`](https://npmjs.com/package/@tsconfig/node23)                     |
-| [Nuxt](#nuxt-tsconfigjson)                         | [`@tsconfig/nuxt`](https://npmjs.com/package/@tsconfig/nuxt)                         |
-| [QJSEngine](#qjsengine-tsconfigjson)               | [`@tsconfig/nuxt`](https://npmjs.com/package/@tsconfig/qtsengine)                    |
-| [React Native](#react-native-tsconfigjson)         | [`@tsconfig/react-native`](https://npmjs.com/package/@tsconfig/react-native)         |
-| [Remix](#remix-tsconfigjson)                       | [`@tsconfig/remix`](https://npmjs.com/package/@tsconfig/remix)                       |
-| [Strictest](#strictest-tsconfigjson)               | [`@tsconfig/strictest`](https://npmjs.com/package/@tsconfig/strictest)               |
-| [Svelte](#svelte-tsconfigjson)                     | [`@tsconfig/svelte`](https://npmjs.com/package/@tsconfig/svelte)                     |
-| [Taro](#taro-tsconfigjson)                         | [`@tsconfig/taro`](https://npmjs.com/package/@tsconfig/taro)                         |
-| [Vite React](#vite-react-tsconfigjson)             | [`@tsconfig/vite-react`](https://npmjs.com/package/@tsconfig/vite-react)             |
+| Name                                                                 | Package                                                                              |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Recommended](#recommended-tsconfigjson)                             | [`@tsconfig/recommended`](https://npmjs.com/package/@tsconfig/recommended)           |
+| [Bun](#bun-tsconfigjson)                                             | [`@tsconfig/bun`](https://npmjs.com/package/@tsconfig/bun)                           |
+| [Create React App](#create-react-app-tsconfigjson)                   | [`@tsconfig/create-react-app`](https://npmjs.com/package/@tsconfig/create-react-app) |
+| [Cypress](#cypress-tsconfigjson)                                     | [`@tsconfig/cypress`](https://npmjs.com/package/@tsconfig/cypress)                   |
+| [Deno](#deno-tsconfigjson)                                           | [`@tsconfig/deno`](https://npmjs.com/package/@tsconfig/deno)                         |
+| [Docusaurus v2](#docusaurus-v2-tsconfigjson)                         | [`@tsconfig/docusaurus`](https://npmjs.com/package/@tsconfig/docusaurus)             |
+| [Ember](#ember-tsconfigjson)                                         | [`@tsconfig/ember`](https://npmjs.com/package/@tsconfig/ember)                       |
+| [Next.js](#nextjs-tsconfigjson)                                      | [`@tsconfig/next`](https://npmjs.com/package/@tsconfig/next)                         |
+| [Node LTS](#node-lts-22-tsconfigjson)                                | [`@tsconfig/node-lts`](https://npmjs.com/package/@tsconfig/node-lts)                 |
+| [Node 10](#node-10-tsconfigjson)                                     | [`@tsconfig/node10`](https://npmjs.com/package/@tsconfig/node10)                     |
+| [Node 12](#node-12-tsconfigjson)                                     | [`@tsconfig/node12`](https://npmjs.com/package/@tsconfig/node12)                     |
+| [Node 14](#node-14-tsconfigjson)                                     | [`@tsconfig/node14`](https://npmjs.com/package/@tsconfig/node14)                     |
+| [Node 16](#node-16-tsconfigjson)                                     | [`@tsconfig/node16`](https://npmjs.com/package/@tsconfig/node16)                     |
+| [Node 17](#node-17-tsconfigjson)                                     | [`@tsconfig/node17`](https://npmjs.com/package/@tsconfig/node17)                     |
+| [Node 18](#node-18-tsconfigjson)                                     | [`@tsconfig/node18`](https://npmjs.com/package/@tsconfig/node18)                     |
+| [Node 19](#node-19-tsconfigjson)                                     | [`@tsconfig/node19`](https://npmjs.com/package/@tsconfig/node19)                     |
+| [Node 20](#node-20-tsconfigjson)                                     | [`@tsconfig/node20`](https://npmjs.com/package/@tsconfig/node20)                     |
+| [Node 21](#node-21-tsconfigjson)                                     | [`@tsconfig/node21`](https://npmjs.com/package/@tsconfig/node21)                     |
+| [Node 22](#node-22-tsconfigjson)                                     | [`@tsconfig/node22`](https://npmjs.com/package/@tsconfig/node22)                     |
+| [Node 23](#node-23-tsconfigjson)                                     | [`@tsconfig/node23`](https://npmjs.com/package/@tsconfig/node23)                     |
+| [Node with TypeScript](node-with-typescript-ts-58-only-tsconfigjson) | [`@tsconfig/node-ts`](https://npmjs.com/package/@tsconfig/node-ts)                   |
+| [Nuxt](#nuxt-tsconfigjson)                                           | [`@tsconfig/nuxt`](https://npmjs.com/package/@tsconfig/nuxt)                         |
+| [QJSEngine](#qjsengine-tsconfigjson)                                 | [`@tsconfig/nuxt`](https://npmjs.com/package/@tsconfig/qtsengine)                    |
+| [React Native](#react-native-tsconfigjson)                           | [`@tsconfig/react-native`](https://npmjs.com/package/@tsconfig/react-native)         |
+| [Remix](#remix-tsconfigjson)                                         | [`@tsconfig/remix`](https://npmjs.com/package/@tsconfig/remix)                       |
+| [Strictest](#strictest-tsconfigjson)                                 | [`@tsconfig/strictest`](https://npmjs.com/package/@tsconfig/strictest)               |
+| [Svelte](#svelte-tsconfigjson)                                       | [`@tsconfig/svelte`](https://npmjs.com/package/@tsconfig/svelte)                     |
+| [Taro](#taro-tsconfigjson)                                           | [`@tsconfig/taro`](https://npmjs.com/package/@tsconfig/taro)                         |
+| [Vite React](#vite-react-tsconfigjson)                               | [`@tsconfig/vite-react`](https://npmjs.com/package/@tsconfig/vite-react)             |
 
 ### Available TSConfigs
 


### PR DESCRIPTION
Fixes #287

The LTS thing including the Node version doesn't work long term; would be good to generate the table as a part of the script too.