### PR TITLE
node-ts: Align with Node docs (for discussion)

### DIFF
--- a/bases/node-ts.json
+++ b/bases/node-ts.json
@@ -4,9 +4,6 @@
   "docs": "https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option",
   "_version": "23.6.0",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "nodenext",
-    "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true

--- a/bases/node-ts.json
+++ b/bases/node-ts.json
@@ -4,6 +4,10 @@
   "docs": "https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option",
   "_version": "23.6.0",
   "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true
   }


### PR DESCRIPTION
This aligns `node-ts.json` with the recommended tsconfig in the Node docs for built-in `*.ts` support.

https://nodejs.org/api/typescript.html#type-stripping

I realize this was discussed two months ago in https://github.com/tsconfig/bases/pull/293 but I missed that first time around and reading it back, it doesn't seem to directly answer the question of why these are not aligned.  So please consider this a low-urgency discussion topic rather than something to be landed.