### PR TITLE
Add rewriteRelativeImportExtensions to node-ts

### DIFF
--- a/bases/node-ts.json
+++ b/bases/node-ts.json
@@ -1,9 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node with TypeScript (TS >=5.8 ONLY)",
-  "docs": "https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option",
+  "docs": [
+    "https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#path-rewriting-for-relative-paths",
+    "https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option"
+  ],
   "_version": "23.6.0",
   "compilerOptions": {
+    "rewriteRelativeImportExtensions": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true
   }


### PR DESCRIPTION
See [the added TS blog link](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#path-rewriting-for-relative-paths), but the TLDR is this is a version of `allowImportingTsExtensions` that works when building.

You need either one if you are importing TS files under node ts, but this does the actual transform to what node expects after build, so it's needed if you have code you want to both use in a script and when built. There doesn't seem to be a downside from reading the blog post?

Not sure about making `docs` an array, but it doesn't seem to be a member of the schema at least, so hopefully nobody is depending on the structure.