### PR TITLE
feat: set module: nodenext for node bases >=20

### DIFF
--- a/bases/node20.json
+++ b/bases/node20.json
@@ -5,7 +5,7 @@
 
   "compilerOptions": {
     "lib": ["es2023"],
-    "module": "node16",
+    "module": "nodenext",
     "target": "es2022",
 
     "strict": true,

--- a/bases/node21.json
+++ b/bases/node21.json
@@ -5,7 +5,7 @@
 
   "compilerOptions": {
     "lib": ["es2023"],
-    "module": "node16",
+    "module": "nodenext",
     "target": "es2022",
 
     "strict": true,

--- a/bases/node22.json
+++ b/bases/node22.json
@@ -5,7 +5,7 @@
 
   "compilerOptions": {
     "lib": ["es2023"],
-    "module": "node16",
+    "module": "nodenext",
     "target": "es2022",
 
     "strict": true,

--- a/bases/node23.json
+++ b/bases/node23.json
@@ -5,7 +5,7 @@
 
   "compilerOptions": {
     "lib": ["es2024"],
-    "module": "node16",
+    "module": "nodenext",
     "target": "es2024",
 
     "strict": true,


### PR DESCRIPTION
Closes https://github.com/tsconfig/bases/issues/279

Set `module: nodenext` for node bases >= 20 (`node20`, `node21`, `node22`, `node23` bases) per typescript 5.8 recommendations

This adds support to `require(esm)` feature supported in node 22 and more recently node 20

- See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-8.html#support-for-require-of-ecmascript-modules-in---module-nodenext
- require(esm) in node20, https://nodejs.org/en/blog/release/v20.19.0/#requireesm-is-now-enabled-by-default

> TypeScript 5.8 supports this behavior under the --module nodenext flag. When --module nodenext is enabled, TypeScript will avoid issuing errors on these require() calls to ESM files.
> 
> Because this feature may be back-ported to older versions of Node.js, there is currently no stable --module nodeXXXX option that enables this behavior; however, we predict future versions of TypeScript may be able to stabilize the feature under node20. In the meantime, we encourage users of Node.js 22 and newer to use --module nodenext, while library authors and users of older Node.js versions should remain on --module node16 (or make the minor update to [--module node18](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-8.html#--module-node18)).

