### PR TITLE
[Ember] Disable declaration generation

### DIFF
--- a/bases/ember.json
+++ b/bases/ember.json
@@ -74,12 +74,12 @@
     // without this flag.
     "experimentalDecorators": true,
 
-    // Support generation of source maps. Note: you must *also* enable source
-    // maps in your `ember-cli-babel` config and/or `babel.config.js`.
-    "declaration": true,
-    "declarationMap": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
+    // We don't use TS for compilation, so we can disable these.
+    // Library authors should set declaration and declarationMap to true, however
+    "declaration": false,
+    "declarationMap": false,
+    "inlineSourceMap": false,
+    "inlineSources": false,
 
     // Don't implicitly pull in declarations from `@types` packages unless we
     // actually import from them AND the package in question doesn't bring its


### PR DESCRIPTION
I'm not sure when declaration generation was added (maybe it was me :see_no_evil: haha), but in apps, its not correct to generate declarations.

declarations are meant for library dev.