### PR TITLE
docs: fix typo in `node-ts` anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We target the latest stable version of TypeScript, note that because we want to 
 | [Node 21](#node-21-tsconfigjson)                                     | [`@tsconfig/node21`](https://npmjs.com/package/@tsconfig/node21)                     |
 | [Node 22](#node-22-tsconfigjson)                                     | [`@tsconfig/node22`](https://npmjs.com/package/@tsconfig/node22)                     |
 | [Node 23](#node-23-tsconfigjson)                                     | [`@tsconfig/node23`](https://npmjs.com/package/@tsconfig/node23)                     |
-| [Node with TypeScript](node-with-typescript-ts-58-only-tsconfigjson) | [`@tsconfig/node-ts`](https://npmjs.com/package/@tsconfig/node-ts)                   |
+| [Node with TypeScript](#node-with-typescript-ts-58-only-tsconfigjson)| [`@tsconfig/node-ts`](https://npmjs.com/package/@tsconfig/node-ts)                   |
 | [Nuxt](#nuxt-tsconfigjson)                                           | [`@tsconfig/nuxt`](https://npmjs.com/package/@tsconfig/nuxt)                         |
 | [QJSEngine](#qjsengine-tsconfigjson)                                 | [`@tsconfig/qjsengine`](https://npmjs.com/package/@tsconfig/qtsengine)               |
 | [React Native](#react-native-tsconfigjson)                           | [`@tsconfig/react-native`](https://npmjs.com/package/@tsconfig/react-native)         |


### PR DESCRIPTION
## Summary

Adds a missing `#` anchor in the link for the `node-ts` config
Fixes https://github.com/tsconfig/bases/pull/297#discussion_r2019742802

## Details

- the missing `#` meant that the link instead ended up incorrectly going to the non-existent file at `https://github.com/tsconfig/bases/blob/main/node-with-typescript-ts-58-only-tsconfigjson`, which would 404

## Verification

The link now works; can view the [rendered commit](https://github.com/tsconfig/bases/blob/ff2dd6d5953ec4e5d977e187631d5b2f0bb86e31/README.md) to double check