### PR TITLE
feat: add Iterator support for node 22 and 23 bases

### DIFF
--- a/bases/node22.json
+++ b/bases/node22.json
@@ -4,7 +4,7 @@
   "_version": "22.0.0",
 
   "compilerOptions": {
-    "lib": ["es2023"],
+    "lib": ["es2023", "ESNext.Iterator"],
     "module": "nodenext",
     "target": "es2022",
 

--- a/bases/node23.json
+++ b/bases/node23.json
@@ -4,7 +4,7 @@
   "_version": "23.0.0",
 
   "compilerOptions": {
-    "lib": ["es2024"],
+    "lib": ["es2024", "ESNext.Iterator"],
     "module": "nodenext",
     "target": "es2024",
 


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Iterator

The iterator constructor is available for node >=22

![image](https://github.com/user-attachments/assets/f9567842-712a-4979-9fa8-93fb99f047e8)
