### PR TITLE
ci: npm publish generate provenance

### DIFF
--- a/scripts/deploy-changed-npm-packages.ts
+++ b/scripts/deploy-changed-npm-packages.ts
@@ -21,7 +21,7 @@ for (const dirEntry of Deno.readDirSync("packages")) {
 
   if (upload) {
     const process = Deno.run({
-      cmd: ["npm", "publish", "--access", "public"],
+      cmd: ["npm", "publish", "--provenance", "--access", "public"],
       stdout: "piped",
       cwd: path.join("packages", dirEntry.name),
       env: { NODE_AUTH_TOKEN: Deno.env.get("NODE_AUTH_TOKEN")! },


### PR DESCRIPTION
See https://docs.npmjs.com/generating-provenance-statements

> This allows you to publicly establish where a package was built and who published a package, which can increase supply-chain security for your packages.