### PR TITLE
Update Vite React config to match Vite 6.3.5 template

### DIFF
--- a/bases/vite-react.json
+++ b/bases/vite-react.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Vite React",
-  "_version": "3.4.0",
+  "_version": "6.3.5",
 
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
@@ -12,9 +12,9 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
@@ -23,6 +23,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   }


### PR DESCRIPTION
This PR updates the Vite React config to match the Vite 6.3.5 template (https://github.com/vitejs/vite/blob/v6.3.5/packages/create-vite/template-react-ts/tsconfig.app.json), which is currently the latest version.