### PR TITLE
update: use latest bun tsconfig in docs

### DIFF
--- a/bases/bun.json
+++ b/bases/bun.json
@@ -5,10 +5,10 @@
   "docs": "https://bun.sh/docs/typescript",
 
   "compilerOptions": {
-    // Enable latest features
-    "lib": ["ESNext", "DOM"],
+    // Environment setup & latest features
+    "lib": ["ESNext"],
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "Preserve",
     "moduleDetection": "force",
     "jsx": "react-jsx",
     "allowJs": true,
@@ -23,10 +23,12 @@
     "strict": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
 
-    // Some stricter flags
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noPropertyAccessFromIndexSignature": true
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
   }
 }


### PR DESCRIPTION
This pull request updates the TypeScript configuration in `bases/bun.json` to refine the environment setup, enable stricter type-checking options, and adjust default strictness flags for better flexibility. Based on [bun docs](https://bun.sh/docs/typescript).

### TypeScript configuration updates:

* Updated the `lib` option to remove `"DOM"`, focusing only on `"ESNext"`, and changed the `module` option from `"ESNext"` to `"Preserve"` for better compatibility with bundlers.
* Enabled new stricter type-checking options: `noUncheckedIndexedAccess` and `noImplicitOverride`, improving type safety and ensuring explicit overrides in subclass methods.
* Adjusted the default strictness flags by disabling `noUnusedLocals`, `noUnusedParameters`, and `noPropertyAccessFromIndexSignature` to provide more flexibility during development.