### PR TITLE
update node-lts to follow latest node22 config

### DIFF
--- a/bases/node-lts.json
+++ b/bases/node-lts.json
@@ -6,9 +6,12 @@
   "_version": "22.0.0",
   "compilerOptions": {
     "lib": [
-      "es2023"
+      "es2024",
+      "ESNext.Array",
+      "ESNext.Collection",
+      "ESNext.Iterator"
     ],
-    "module": "node16",
+    "module": "nodenext",
     "target": "es2022",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This PR updates node-lts using the generate-lts to use the latest tsconfig from node22.

In the future I think this should be some sort of CI check and/or pre-commit hook/test.