### PR TITLE
Update Vite React config to match Vite 7.0.0 template

### DIFF
--- a/bases/vite-react.json
+++ b/bases/vite-react.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Vite React",
-  "_version": "6.3.5",
+  "_version": "7.0.0",
 
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
This PR updates the Vite React config to match the Vite 7.0.0 template (https://github.com/vitejs/vite/blob/v7.0.0/packages/create-vite/template-react-ts/tsconfig.app.json), which switched from `ES2020` to `ES2022` in its `target` and `lib` fields.