### PR TITLE
Deprecated @tsconfig/ember in favor of @ember/app-tsconfig and @ember/library-tsconfig

### DIFF
--- a/bases/ember.json
+++ b/bases/ember.json
@@ -3,6 +3,7 @@
   "display": "Ember",
   "docs": "https://guides.emberjs.com/release/typescript/",
   "_version": "3.0.0",
+  "_deprecated": true,  
 
   // This is the base config used by Ember apps and addons. When actually used
   // via Ember CLI (e.g. ember-cli-typescript's blueprint), it additionally has


### PR DESCRIPTION
New configs are here: https://github.com/ember-cli/tsconfigs
- For Apps: https://github.com/ember-cli/tsconfigs/tree/main/%40ember/app-tsconfig
- For Libraries: https://github.com/ember-cli/tsconfigs/tree/main/%40ember/library-tsconfig


:wave: 

When publishing this package next with the deprecation message, can you customize the message on NPM?

It should say something like:

```
@tsconfig/ember is deprecated. Please migrate to `@ember/app-tsconfig` or `@ember/library-tsconfig`
```


Thanks!