### PR TITLE
add verbatimModuleSyntax to strictest

### DIFF
--- a/bases/strictest.json
+++ b/bases/strictest.json
@@ -13,6 +13,7 @@
     "noUnusedParameters": true,
 
     "isolatedModules": true,
+    "verbatimModuleSyntax": true,
 
     "checkJs": true,
 


### PR DESCRIPTION
[`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/verbatimModuleSyntax.html) was implemented in TS 5.0 but was never added to this base config.

But it changes the output of transpiling, instead of just adding a new error case, so use its predecessor, [`importsNotUsedAsValues: "error"`](https://www.typescriptlang.org/tsconfig/importsNotUsedAsValues.html), from TS 3.8.

The new `erasableSyntaxOnly` would be too code-breaking to add even to `strictest`, though.

Related to: #212