### PR TITLE
sync recommended with 'tsc --init'

### DIFF
--- a/bases/recommended.json
+++ b/bases/recommended.json
@@ -1,9 +1,16 @@
 {
   "compilerOptions": {
-    "target": "es2016",
-    "module": "commonjs",
+    "module": "node20",
+    "target": "es2023",
     "esModuleInterop": true,
+    "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "moduleDetection": "force",
+    "noUncheckedIndexedAccess": true,
+    "noUncheckedSideEffectImports": true,
+    "verbatimModuleSyntax": true,
     "strict": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
Per https://github.com/tsconfig/bases/pull/15#issuecomment-656857651 base `recommended` on the new output of `tsc --init` in TS 5.9 (https://github.com/microsoft/TypeScript/pull/61813)

Exception: downgrade the moving target `nodenext` to `node20`, and set the `target` field to the default target implied by `node20` (`es2023`).