### PR TITLE
Deploy bases when any other base changes

### DIFF
--- a/scripts/deploy-changed-npm-packages.ts
+++ b/scripts/deploy-changed-npm-packages.ts
@@ -36,6 +36,19 @@ for (const dirEntry of Deno.readDirSync("packages")) {
 }
 
 if (uploaded.length) {
+  // If there's any uploads, we need to update the combined package too
+    const process = Deno.run({
+      cmd: ["npm", "publish", "--provenance", "--access", "public"],
+      stdout: "piped",
+      cwd: path.join("packages", "bases"),
+      env: { NODE_AUTH_TOKEN: Deno.env.get("NODE_AUTH_TOKEN")! },
+    });
+
+    for await (const line of bufio.readLines(process.stdout!)) {
+      console.warn(line);
+    }
+
+
   console.log("Uploaded: ", uploaded.join(", "))
 } else {
   console.log("No uploads")


### PR DESCRIPTION
Currently the 'did anything change' check would not pass on the bases package from #320 - think this should be enough to handle that