### PR TITLE
fix(strictest)!: don't implicitly allow js in strictest config

### DIFF
--- a/bases/strictest.json
+++ b/bases/strictest.json
@@ -14,7 +14,6 @@
 
     "isolatedModules": true,
 
-    "checkJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
This pull request removes `checkJs` from the `strictest` configuration.

The `strictest` config currently enables `checkJs`. Since [TypeScript 4.1](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#checkjs-implies-allowjs), when `allowJs` is not explicitly defined, its value is inferred from `checkJs`. This results in `strictest` implicitly setting `allowJs: true`, which can lead to [unexpected behavior](https://github.com/tsconfig/bases/pull/218#issuecomment-1720994555) and [conflicts with other compiler options](https://github.com/tsconfig/bases/issues/199).

For example, using `strictest` with `isolatedDeclarations: true` causes the following error because `allowJs` and `isolatedDeclarations` cannot be used together:

```sh
Option 'allowJs' cannot be specified with option 'isolatedDeclarations'.
```

This change removes `checkJs` from the `strictest` configuration to prevent `allowJs` from being enabled by default.

For reference, here's the [code](https://github.com/microsoft/TypeScript/blob/d3be7e171bf3149fe93c3ce5a85280f1eba3ef8d/src/compiler/utilities.ts#L9166-L9171)

```js
    allowJs: {
        dependencies: ["checkJs"],
        computeValue: compilerOptions => {
            return compilerOptions.allowJs === undefined ? !!compilerOptions.checkJs : compilerOptions.allowJs;
        },
    },
```