### PR TITLE
Revert "chore: Remove redundant esModuleInterop"

### DIFF
--- a/bases/node-lts.json
+++ b/bases/node-lts.json
@@ -5,10 +5,16 @@
   "display": "Node LTS (22)",
   "_version": "22.0.0",
   "compilerOptions": {
-    "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator"],
+    "lib": [
+      "es2024",
+      "ESNext.Array",
+      "ESNext.Collection",
+      "ESNext.Iterator"
+    ],
     "module": "nodenext",
     "target": "es2022",
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node12.json
+++ b/bases/node12.json
@@ -9,6 +9,7 @@
     "target": "es2019",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node14.json
+++ b/bases/node14.json
@@ -9,6 +9,7 @@
     "target": "es2020",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node16.json
+++ b/bases/node16.json
@@ -9,6 +9,7 @@
     "target": "es2021",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node17.json
+++ b/bases/node17.json
@@ -8,6 +8,7 @@
     "target": "es2022",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true,
     "moduleResolution": "node16"

--- a/bases/node18.json
+++ b/bases/node18.json
@@ -10,6 +10,7 @@
     "target": "es2022",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node19.json
+++ b/bases/node19.json
@@ -10,6 +10,7 @@
     "target": "es2022",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node20.json
+++ b/bases/node20.json
@@ -9,6 +9,7 @@
     "target": "es2022",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node21.json
+++ b/bases/node21.json
@@ -9,6 +9,7 @@
     "target": "es2022",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node22.json
+++ b/bases/node22.json
@@ -9,6 +9,7 @@
     "target": "es2022",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node23.json
+++ b/bases/node23.json
@@ -4,17 +4,12 @@
   "_version": "23.0.0",
 
   "compilerOptions": {
-    "lib": [
-      "es2024",
-      "ESNext.Array",
-      "ESNext.Collection",
-      "ESNext.Iterator",
-      "ESNext.Promise"
-    ],
+    "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator", "ESNext.Promise"],
     "module": "nodenext",
     "target": "es2024",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }

--- a/bases/node24.json
+++ b/bases/node24.json
@@ -15,6 +15,7 @@
     "target": "es2024",
 
     "strict": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16"
   }


### PR DESCRIPTION
Reverts tsconfig/bases#330 - we don't need to do a breaking change for these gains 👍🏻 