### PR TITLE
feat(ember): set "target" to "es2024"

### DIFF
--- a/bases/ember.json
+++ b/bases/ember.json
@@ -9,7 +9,7 @@
   // via Ember CLI (e.g. ember-cli-typescript's blueprint), it additionally has
   // `compilerOptions.baseUrl`, `compilerOptions.paths`, and `include` set.
   "compilerOptions": {
-    "target": "es2023",
+    "target": "es2024",
     "module": "esnext",
     "moduleResolution": "bundler",
 


### PR DESCRIPTION
Bump target to ES2024 for `Object.groupBy`, `Map.groupBy`, etc.