### PR TITLE
update: add ESNext.Error for node24

### DIFF
--- a/bases/node24.json
+++ b/bases/node24.json
@@ -8,6 +8,7 @@
       "es2024",
       "ESNext.Array",
       "ESNext.Collection",
+      "ESNext.Error",
       "ESNext.Iterator",
       "ESNext.Promise"
     ],


### PR DESCRIPTION
It looks like Node 24 [added support](https://nodejs.org/en/blog/release/v24.0.0#v8-136) for Error.isError, which is specified in [ESNext.Error](https://github.com/microsoft/TypeScript/blob/main/src/lib/esnext.error.d.ts).