### PR TITLE
chore: add `files.associations` to VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "deno.enable": true,
   "[typescript]": {
     "editor.defaultFormatter": "denoland.vscode-deno"
-  }
+  },
+  "files.associations": {
+    "**/bases/*.json": "jsonc"
+  },
 }


### PR DESCRIPTION
This is a quality-of-life type of improvement.

Without setting `files.associations`, I see red squiggly errors in files that have comments (e.g. `bases/bun.json` or `bases/svelte.json`).