### PR TITLE
Change module option to 'NodeNext' in node22.json

### DIFF
--- a/bases/node22.json
+++ b/bases/node22.json
@@ -5,7 +5,7 @@
 
   "compilerOptions": {
     "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator"],
-    "module": "nodenext",
+    "module": "NodeNext",
     "target": "es2022",
 
     "strict": true,


### PR DESCRIPTION
- to silence the compilerOption/module warnings, it seems its case sensitive, though either way it works,but the warnings is soo annoying