### PR TITLE
feat: add types: ["node"] to all node tsconfig bases

### DIFF
--- a/bases/node-lts.json
+++ b/bases/node-lts.json
@@ -14,6 +14,7 @@
     ],
     "module": "nodenext",
     "target": "es2024",
+    "types": ["node"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bases/node10.json
+++ b/bases/node10.json
@@ -6,6 +6,7 @@
     "lib": ["es2018"],
     "module": "commonjs",
     "target": "es2018",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node12.json
+++ b/bases/node12.json
@@ -7,6 +7,7 @@
     "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
     "module": "node16",
     "target": "es2019",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node14.json
+++ b/bases/node14.json
@@ -7,6 +7,7 @@
     "lib": ["es2020"],
     "module": "node16",
     "target": "es2020",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node16.json
+++ b/bases/node16.json
@@ -7,6 +7,7 @@
     "lib": ["es2021"],
     "module": "node16",
     "target": "es2021",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node17.json
+++ b/bases/node17.json
@@ -6,6 +6,7 @@
     "lib": ["es2022"],
     "module": "node16",
     "target": "es2022",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node18.json
+++ b/bases/node18.json
@@ -8,6 +8,7 @@
     "lib": ["es2023"],
     "module": "node16",
     "target": "es2022",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node19.json
+++ b/bases/node19.json
@@ -8,6 +8,7 @@
     "lib": ["es2023"],
     "module": "node16",
     "target": "es2022",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node20.json
+++ b/bases/node20.json
@@ -7,6 +7,7 @@
     "lib": ["es2023"],
     "module": "nodenext",
     "target": "es2022",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node21.json
+++ b/bases/node21.json
@@ -7,6 +7,7 @@
     "lib": ["es2023"],
     "module": "nodenext",
     "target": "es2022",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node22.json
+++ b/bases/node22.json
@@ -7,6 +7,7 @@
     "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator"],
     "module": "nodenext",
     "target": "es2022",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node23.json
+++ b/bases/node23.json
@@ -7,6 +7,7 @@
     "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator", "ESNext.Promise"],
     "module": "nodenext",
     "target": "es2024",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node24.json
+++ b/bases/node24.json
@@ -14,6 +14,7 @@
     ],
     "module": "nodenext",
     "target": "es2024",
+    "types": ["node"],
 
     "strict": true,
     "esModuleInterop": true,

--- a/bases/node26.json
+++ b/bases/node26.json
@@ -7,6 +7,7 @@
     "lib": ["es2025", "ESNext.Collection", "ESNext.Temporal"],
     "module": "nodenext",
     "target": "es2025",
+    "types": ["node"],
 
     "esModuleInterop": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary

- Adds `"types": ["node"]` to all `nodeXX` and `node-lts` base configs
- Fixes #351 - TypeScript 6/7 changes `types` default from `undefined` (include all `@types/*`) to `[]` (include none)

## Backwards compatibility note

Setting `types: ["node"]` explicitly is **not fully backwards compatible** for TS5 users. Previously, with `types` unset, TypeScript auto-included all `@types/*` packages from `node_modules` (e.g. `@types/jest`, `@types/react`). With this change, only `@types/node` is included. Users relying on other `@types/*` packages will need to add them to their own `types` array.

I've left versioning as-is for maintainers to decide on the appropriate bump (minor vs major).