### PR TITLE
Update Vite React config to match Vite 8.0.6 template

### DIFF
--- a/bases/vite-react.json
+++ b/bases/vite-react.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://www.schemastore.org/tsconfig",
   "display": "Vite React",
-  "_version": "7.0.0",
+  "_version": "8.0.6",
 
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2022",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
+    "target": "es2023",
+    "lib": ["ES2023", "DOM"],
+    "module": "esnext",
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -20,11 +20,9 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noFallthroughCasesInSwitch": true
   }
 }


### PR DESCRIPTION
This PR updates the Vite React config to match the Vite 8.0.6 template (https://github.com/vitejs/vite/blob/v8.0.6/packages/create-vite/template-react-ts/tsconfig.app.json), which is currently the latest version.

Here's what changed and why:
- `"target": "ES2022"` was changed to `"target": "es2023"`.
  - This aligns with the newer default browser targets in Vite 8 (https://vite.dev/guide/migration#default-browser-target-change).
- `"useDefineForClassFields": true` was dropped.
  - `useDefineForClassFields` has been `true` by default for targets of `ES2022` and higher since TypeScript 4.3 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-3.html#usedefineforclassfields-now-defaults-to-true-on-esnext-and-eventually-on-es2022).
- `"lib": ["ES2022", "DOM", "DOM.Iterable"]` was changed to `"lib": ["ES2023", "DOM"]`.
  - The `ES2022` library was changed to `ES2023` to align with the `target` change.
  - The `DOM` library now includes `DOM.Iterable` as of TypeScript 6.0 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#the-dom-lib-now-contains-domiterable-and-domasynciterable), so the latter can be dropped.
- `"module": "ESNext"` was changed to `"module": "esnext"`.
- `"types": ["vite/client"]` was added.
  - `types` now defaults to `[]` in TypeScript 6.0 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#types-now-defaults-to-), and this is the preferred way to make Vite's client types available in user code according to the documentation (https://vite.dev/guide/features#client-types).
- `"strict": true` was dropped.
  - `strict` is now `true` by default in TypeScript 6.0 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#simple-default-changes).
- `"noUncheckedSideEffectImports": true` was dropped.
  - `noUncheckedSideEffectImports` is now `true` by default in TypeScript 6.0 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#simple-default-changes).