### PR TITLE
feat(node26): add ESNext.Intl and ESNext.Date to lib

### DIFF
--- a/bases/node26.json
+++ b/bases/node26.json
@@ -4,7 +4,7 @@
   "_version": "26.1.0",
 
   "compilerOptions": {
-    "lib": ["es2025", "ESNext.Collection", "ESNext.Temporal", "ESNext.Intl"],
+    "lib": ["es2025", "ESNext.Collection", "ESNext.Temporal", "ESNext.Intl", "ESNext.Date"],
     "module": "nodenext",
     "target": "es2025",
 

--- a/bases/node26.json
+++ b/bases/node26.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://www.schemastore.org/tsconfig",
   "display": "Node 26",
-  "_version": "26.0.0",
+  "_version": "26.1.0",
 
   "compilerOptions": {
-    "lib": ["es2025", "ESNext.Collection", "ESNext.Temporal"],
+    "lib": ["es2025", "ESNext.Collection", "ESNext.Temporal", "ESNext.Intl"],
     "module": "nodenext",
     "target": "es2025",
 


### PR DESCRIPTION
The Node 26 base sets `lib` to `["es2025", "ESNext.Collection", "ESNext.Temporal"]`. `ESNext.Temporal` declares the `Temporal` namespace, but the `Intl` integration lives in `ESNext.Intl`, so formatting a Temporal value does not type check even though Node 26 supports it:

```ts
const formatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "long" });
const date = Temporal.PlainDate.from("2026-08-10");

formatter.format(date);
// error TS2345: Argument of type 'PlainDate' is not assignable to
// parameter of type 'number | Date | undefined'.
```

Adding `ESNext.Intl` compiles clean.

`ESNext.Intl` declares two things, and Node 26 implements both. Checked against Node 26.3.1:

Temporal-aware `Intl.DateTimeFormat` methods (`format`, `formatToParts`, `formatRange`, `formatRangeToParts`):

```
> new Intl.DateTimeFormat("de-DE").format(Temporal.PlainDate.from("2026-08-10"))
'10.8.2026'
> new Intl.DateTimeFormat("de-DE").formatRange(Temporal.PlainDate.from("2026-08-10"), Temporal.PlainDate.from("2026-08-12"))
'10.–12.08.2026'
```

Intl Locale Info methods on `Intl.Locale`:

```
> const locale = new Intl.Locale("de-DE");
> locale.getCalendars()        // [ 'gregory' ]
> locale.getCollations()       // [ 'emoji', 'eor', 'phonebk' ]
> locale.getHourCycles()       // [ 'h23' ]
> locale.getNumberingSystems() // [ 'latn' ]
> locale.getTextInfo()         // { direction: 'ltr' }
> locale.getTimeZones()        // [ 'Europe/Berlin', 'Europe/Busingen' ]
> locale.getWeekInfo()         // { firstDay: 1, weekend: [ 6, 7 ] }
```

So nothing in `ESNext.Intl` is declared ahead of what the runtime provides.

`_version` bumped to `26.1.0`, matching how other Node bases version revisions.


---

Second commit: the same reasoning applies to `ESNext.Date`. The Temporal proposal adds one method to `Date` — `Date.prototype.toTemporalInstant()`, the migration bridge from legacy dates — and Node 26 ships it, but its declaration lives in `ESNext.Date`:

```ts
new Date().toTemporalInstant();
// error TS2339: Property 'toTemporalInstant' does not exist on type 'Date'.
```

With both additions, the base covers the complete Temporal lib surface (`ESNext.Temporal`, `ESNext.Intl`, `ESNext.Date`).
